### PR TITLE
x64 and Windows support for ndarray

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "Boost.NumPy"]
 	path = Boost.NumPy
-	url = git@github.com:ChrislS/Boost.NumPy.git
-    branch = master
+	url = https://github.com/ChrislS/Boost.NumPy.git
+	branch = master

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "Boost.NumPy"]
 	path = Boost.NumPy
-	url = git://github.com/ndarray/Boost.NumPy.git
+	url = git@github.com:ChrislS/Boost.NumPy.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "Boost.NumPy"]
 	path = Boost.NumPy
 	url = git@github.com:ChrislS/Boost.NumPy.git
+    branch = master

--- a/include/SConscript
+++ b/include/SConscript
@@ -23,7 +23,7 @@ generated = ["ndarray/ArrayRef.h",
              "ndarray/eigen/bp/auto/Array.h",
              "ndarray/eigen/bp/auto/Matrix.h",
              ]
-m4include = Dir("#m4").abspath
+m4include = Dir("../m4").abspath
 m4flags = "-I%s" % m4include
 headers = [env.M4(filename, "%s.m4" % filename, M4FLAGS=[m4flags]) for filename in generated]
 

--- a/include/ndarray/Array.h
+++ b/include/ndarray/Array.h
@@ -86,7 +86,7 @@ public:
      *
      *  This is implemented in initialization.h.
      */
-    explicit Array(int n1, int n2=1, int n3=1, int n4=1, int n5=1, int n6=1, int n7=1, int n8=1);
+    explicit Array(std::size_t n1, std::size_t n2=1, std::size_t n3=1, std::size_t n4=1, std::size_t n5=1, std::size_t n6=1, std::size_t n7=1, std::size_t n8=1);
 
     /**
      *  @brief Non-converting shallow assignment.

--- a/include/ndarray/ArrayBase.h
+++ b/include/ndarray/ArrayBase.h
@@ -17,7 +17,8 @@
  *  @brief Definitions for ArrayBase.
  */
 
-
+#include <cstddef>
+ 
 #include <boost/iterator/counting_iterator.hpp>
 
 #include "ndarray/ExpressionBase.h"
@@ -60,7 +61,7 @@ public:
     /// @brief Number of guaranteed row-major contiguous dimensions, counted from the end (boost::mpl::int_).
     typedef typename Traits::RMC RMC;
     /// @brief Vector type for N-dimensional indices.
-    typedef Vector<int,ND::value> Index;
+    typedef Vector<std::size_t,ND::value> Index;
     /// @brief ArrayRef to a reverse-ordered contiguous array; the result of a call to transpose().
     typedef ArrayRef<Element,ND::value,-RMC::value> FullTranspose;
     /// @brief ArrayRef to a noncontiguous array; the result of a call to transpose(...).
@@ -71,7 +72,7 @@ public:
     typedef ArrayRef<Element,ND::value,RMC::value> Deep;
 
     /// @brief Return a single subarray.
-    Reference operator[](int n) const {
+    Reference operator[](std::size_t n) const {
         return Traits::makeReference(
             this->_data + n * this->template getStride<0>(),
             this->_core
@@ -111,12 +112,12 @@ public:
     Manager::Ptr getManager() const { return this->_core->getManager(); }
 
     /// @brief Return the size of a specific dimension.
-    template <int P> int getSize() const {
+    template <int P> size_t getSize() const {
         return detail::getDimension<P>(*this->_core).getSize();
     }
 
     /// @brief Return the stride in a specific dimension.
-    template <int P> int getStride() const {
+    template <int P> std::size_t getStride() const {
         return detail::getDimension<P>(*this->_core).getStride();
     }
 
@@ -127,15 +128,15 @@ public:
     Index getStrides() const { Index r; this->_core->fillStrides(r); return r; }
 
     /// @brief Return the total number of elements in the array.
-    int getNumElements() const { return this->_core->getNumElements(); }
+    std::size_t getNumElements() const { return this->_core->getNumElements(); }
 
     /// @brief Return a view of the array with the order of the dimensions reversed.
     FullTranspose transpose() const {
         Index shape = getShape();
         Index strides = getStrides();
-        for (int n=0; n < ND::value / 2; ++n) {
-            std::swap(shape[n], shape[ND::value-n-1]);
-            std::swap(strides[n], strides[ND::value-n-1]);
+        for (std::size_t n=0; n < static_cast<std::size_t>(ND::value / 2); ++n) {
+            std::swap(shape[n], shape[static_cast<std::size_t>(ND::value-n-1)]);
+            std::swap(strides[n], strides[static_cast<std::size_t>(ND::value-n-1)]);
         }
         return FullTranspose(
             getData(),
@@ -149,7 +150,7 @@ public:
         Index newStrides;
         Index oldShape = getShape();
         Index oldStrides = getStrides();
-        for (int n=0; n < ND::value; ++n) {
+        for (std::size_t n=0; n < static_cast<std::size_t>(ND::value); ++n) {
             newShape[n] = oldShape[order[n]];
             newStrides[n] = oldStrides[order[n]];
         }
@@ -159,7 +160,7 @@ public:
         );
     }
 
-    /// @brief Return a Array view to this.
+    /// @brief Return an Array view to this.
     Shallow const shallow() const { return Shallow(this->getSelf()); }
 
     /// @brief Return an ArrayRef view to this.

--- a/include/ndarray/ArrayBase.h
+++ b/include/ndarray/ArrayBase.h
@@ -74,14 +74,22 @@ public:
     /// @brief Return a single subarray.
     Reference operator[](std::size_t n) const {
         return Traits::makeReference(
-            this->_data + n * this->template getStride<0>(),
+            this->_data + n * this->
+			#ifndef _MSC_VER
+			template
+			#endif
+			getStride<0>(),
             this->_core
         );
     }
 
     /// @brief Return a single element from the array.
     Element & operator[](Index const & i) const {
-        return *(this->_data + this->_core->template computeOffset(i));
+        return *(this->_data + this->_core->
+			#ifndef _MSC_VER
+			template
+			#endif
+			computeOffset(i));
     }
 
     /// @brief Return an Iterator to the beginning of the array.
@@ -89,16 +97,32 @@ public:
         return Traits::makeIterator(
             this->_data,
             this->_core,
-            this->template getStride<0>()
+            this->
+				#ifndef _MSC_VER
+				template
+				#endif
+				getStride<0>()
         );
     }
 
     /// @brief Return an Iterator to one past the end of the array.
     Iterator end() const {
         return Traits::makeIterator(
-            this->_data + this->template getSize<0>() * this->template getStride<0>(), 
+            this->_data + this->
+				#ifndef _MSC_VER
+				template
+				#endif
+				getSize<0>() * this->
+					#ifndef _MSC_VER
+					template
+					#endif
+					getStride<0>(), 
             this->_core,
-            this->template getStride<0>()
+            this->
+				#ifndef _MSC_VER
+				template
+				#endif
+				getStride<0>()
         );
     }
 

--- a/include/ndarray/ArrayBaseN.h.m4
+++ b/include/ndarray/ArrayBaseN.h.m4
@@ -49,7 +49,7 @@ private:
  *
  *  @brief Definition of ArrayBaseN, a dimension-specialized CRTP base class for Array and ArrayRef.
  */
-
+#include <cstddef>
 #include "ndarray/ArrayBase.h"
 
 namespace ndarray {
@@ -75,12 +75,12 @@ private:
     ArrayBaseN(Element * data, CorePtr const & core) : Super(data, core) {}
 };
 
-SPECIALIZE(1, `int n0', `n0')
-SPECIALIZE(2, `int n0, int n1', `n0, n1')
-SPECIALIZE(3, `int n0, int n1, int n2', `n0, n1, n2')
-SPECIALIZE(4, `int n0, int n1, int n2, int n3', `n0, n1, n2, n3')
-SPECIALIZE(5, `int n0, int n1, int n2, int n3, int n4', `n0, n1, n2, n3, n4')
-SPECIALIZE(6, `int n0, int n1, int n2, int n3, int n4, int n5', `n0, n1, n2, n3, n4, n5')
+SPECIALIZE(1, `std::size_t n0', `n0')
+SPECIALIZE(2, `std::size_t n0, std::size_t n1', `n0, n1')
+SPECIALIZE(3, `std::size_t n0, std::size_t n1, std::size_t n2', `n0, n1, n2')
+SPECIALIZE(4, `std::size_t n0, std::size_t n1, std::size_t n2, std::size_t n3', `n0, n1, n2, n3')
+SPECIALIZE(5, `std::size_t n0, std::size_t n1, std::size_t n2, std::size_t n3, std::size_t n4', `n0, n1, n2, n3, n4')
+SPECIALIZE(6, `std::size_t n0, std::size_t n1, std::size_t n2, std::size_t n3, std::size_t n4, std::size_t n5', `n0, n1, n2, n3, n4, n5')
 
 } // namespace ndarray
 

--- a/include/ndarray/ArrayRef.h.m4
+++ b/include/ndarray/ArrayRef.h.m4
@@ -156,7 +156,7 @@ private:
     template <typename T_, int N_, int C_> friend class ArrayRef;
     template <typename T_, int N_, int C_> friend struct ArrayTraits;
     template <typename Derived> friend class ArrayBase;
-    template <typename Array_> friend class detail::ArrayAccess;
+    template <typename Array_> friend struct detail::ArrayAccess;
 
     /// @internal @brief Construct an ArrayRef from a pointer and Core.
     ArrayRef(T * data, CorePtr const & core) : Super(data, core) {}

--- a/include/ndarray/ArrayRef.h.m4
+++ b/include/ndarray/ArrayRef.h.m4
@@ -82,7 +82,7 @@ public:
      *
      *  This is implemented in initialization.h.
      */
-    explicit ArrayRef(int n1, int n2=1, int n3=1, int n4=1, int n5=1, int n6=1, int n7=1, int n8=1);
+    explicit ArrayRef(std::size_t n1, std::size_t n2=1, std::size_t n3=1, std::size_t n4=1, std::size_t n5=1, std::size_t n6=1, std::size_t n7=1, std::size_t n8=1);
 
     /**
      *  @brief Non-converting copy constructor.

--- a/include/ndarray/ArrayTraits.h
+++ b/include/ndarray/ArrayTraits.h
@@ -17,6 +17,8 @@
  *  @brief Traits for Array.
  */
 
+#include <cstddef>
+ 
 #include "ndarray_fwd.h"
 #include "ndarray/ExpressionTraits.h"
 #include "ndarray/detail/Core.h"
@@ -54,7 +56,7 @@ struct ArrayTraits {
     static Reference makeReference(Element * data, CorePtr const & core) {
         return Reference(data, core);
     }
-    static Iterator makeIterator(Element * data, CorePtr const & core, int stride) {
+    static Iterator makeIterator(Element * data, CorePtr const & core, std::ptrdiff_t stride) {
         return Iterator(Reference(data, core), stride);
     }
 };
@@ -73,7 +75,7 @@ struct ArrayTraits<T,1,0> {
     static Reference makeReference(Element * data, CorePtr const & core) {
         return *data;
     }
-    static Iterator makeIterator(Element * data, CorePtr const & core, int stride) {
+    static Iterator makeIterator(Element * data, CorePtr const & core, std::ptrdiff_t stride) {
         return Iterator(data, stride);
     }
 };
@@ -92,7 +94,7 @@ struct ArrayTraits<T,1,1> {
     static Reference makeReference(Element * data, CorePtr const & core) {
         return *data;
     }
-    static Iterator makeIterator(Element * data, CorePtr const & core, int stride) {
+    static Iterator makeIterator(Element * data, CorePtr const & core, std::ptrdiff_t stride) {
         return data;
     }
 };
@@ -111,7 +113,7 @@ struct ArrayTraits<T,1,-1> {
     static Reference makeReference(Element * data, CorePtr const & core) {
         return *data;
     }
-    static Iterator makeIterator(Element * data, CorePtr const & core, int stride) {
+    static Iterator makeIterator(Element * data, CorePtr const & core, std::ptrdiff_t stride) {
         return data;
     }
 };

--- a/include/ndarray/ExpressionBase.h
+++ b/include/ndarray/ExpressionBase.h
@@ -11,6 +11,8 @@
 #ifndef NDARRAY_ExpressionBase_h_INCLUDED
 #define NDARRAY_ExpressionBase_h_INCLUDED
 
+#include <cstddef>
+
 /** 
  *  @file ndarray/ExpressionBase.h
  *
@@ -50,12 +52,12 @@ public:
     /// @brief Nested expression or element value type.
     typedef typename ExpressionTraits<Derived>::Value Value;
     /// @brief Vector type for N-dimensional indices.
-    typedef Vector<int,ND::value> Index;
+    typedef Vector<std::size_t,ND::value> Index;
     /// @brief CRTP derived type.
     typedef Derived Self;
 
     /// @brief Return a single nested expression or element.
-    Reference operator[](int n) const { return getSelf().operator[](n); }
+    Reference operator[](std::size_t n) const { return getSelf().operator[](n); }
 
     /// @brief Return the first nested expression or element.
     Reference front() const { return this->operator[](0); }
@@ -70,13 +72,13 @@ public:
     Iterator end() const { return getSelf().end(); }
 
     /// @brief Return the size of a specific dimension.
-    template <int P> int getSize() const { return getSelf().template getSize<P>(); }
+    template <int P> std::size_t getSize() const { return getSelf().template getSize<P>(); }
 
     /// @brief Return a Vector of the sizes of all dimensions.
     Index getShape() const { return getSelf().getShape(); }
 
     /// @brief Return the total number of elements in the expression.
-    int getNumElements() const { return getSelf().getNumElements(); }
+    std::size_t getNumElements() const { return getSelf().getNumElements(); }
 
     /* ------------------------- STL Compatibility -------------------------- */
 
@@ -86,8 +88,8 @@ public:
     typedef Reference reference;
     typedef Reference const_reference;
     typedef Iterator pointer;
-    typedef int difference_type;
-    typedef int size_type;
+    typedef std::ptrdiff_t difference_type;
+    typedef std::size_t size_type;
 
     /// @brief Return the size of the first dimension.
     size_type size() const { return this->template getSize<0>(); }

--- a/include/ndarray/Manager.h
+++ b/include/ndarray/Manager.h
@@ -56,7 +56,7 @@ class SimpleManager : public Manager {
     typedef typename boost::remove_const<T>::type U;
 public:
     
-    static std::pair<Manager::Ptr,T*> allocate(int size) {
+    static std::pair<Manager::Ptr,T*> allocate(std::size_t size) {
         boost::intrusive_ptr<SimpleManager> r(new SimpleManager(size));
         return std::pair<Manager::Ptr,T*>(r, r->_p.get());
     }
@@ -64,7 +64,7 @@ public:
     virtual bool isUnique() const { return true; }
 
 private:
-    explicit SimpleManager(int size) : _p() {
+    explicit SimpleManager(std::size_t size) : _p() {
         if (size > 0) _p.reset(new U[size]);
     }
     boost::scoped_array<U> _p;

--- a/include/ndarray/Vector.h.m4
+++ b/include/ndarray/Vector.h.m4
@@ -30,21 +30,21 @@ define(`VECTOR_ASSIGN',
 define(`VECTOR_BINARY_OP',
 `
     /// @brief Operator overload for Vector $1 Vector.
-    template <typename T, typename U, std::size_t N>
+    template <typename T, typename U, int N>
     Vector<typename Promote<T,U>::Type,N>
     operator $1(Vector<T,N> const & a, Vector<U,N> const & b) {
         Vector<typename Promote<T,U>::Type,N> r(a);
         return r $1= b;
     }
     /** @brief Operator overload for Vector $1 Scalar. */
-    template <typename T, typename U, std::size_t N>
+    template <typename T, typename U, int N>
     Vector<typename Promote<T,U>::Type,N>
     operator $1(Vector<T,N> const & a, U b) {
         Vector<typename Promote<T,U>::Type,N> r(a);
         return r $1= b;
     }
     /** @brief Operator overload for Scalar $1 Vector. */
-    template <typename T, typename U, std::size_t N>
+    template <typename T, typename U, int N>
     Vector<typename Promote<T,U>::Type,N>
     operator $1(U a, Vector<T,N> const & b) {
         Vector<typename Promote<T,U>::Type,N> r(a);
@@ -79,7 +79,7 @@ define(`VECTOR_TYPEDEFS',
 
 #include <boost/iterator/reverse_iterator.hpp>
 #include <boost/utility/enable_if.hpp>
-#include <boost/mpl/size_t.hpp>
+#include <boost/mpl/int.hpp>
 #include <boost/preprocessor/repetition/repeat.hpp>
 #include <boost/preprocessor/repetition/repeat_from_to.hpp>
 #include <boost/preprocessor/repetition/enum.hpp>
@@ -125,12 +125,12 @@ namespace ndarray {
  */
 template <
     typename T, ///< Data type.
-    std::size_t N       ///< Number of elements.
+    int N       ///< Number of elements.
     >
 struct Vector {
     VECTOR_TYPEDEFS
 
-    typedef boost::mpl::size_t<N> ND;
+    typedef boost::mpl::int_<N> ND;
 
     size_type size() const { return static_cast<size_type>(N); }           ///< @brief Return the size of the Vector.
     size_type max_size() const { return static_cast<size_type>(N); }       ///< @brief Return the size of the Vector.
@@ -167,7 +167,7 @@ struct Vector {
     const_reference operator[](std::size_t i) const { return elems[i]; }
 
     /// @brief Create a new Vector that is a subset of this.
-    template <std::size_t Start, std::size_t Stop>
+    template <int Start, int Stop>
     Vector<T,Stop-Start> getRange() const {
         Vector<T,Stop-Start> r;
         std::copy(begin() + Start, begin()+Stop, r.begin());
@@ -175,14 +175,14 @@ struct Vector {
     }
 
     /// @brief Create a new Vector from the first M elements of this.
-    template <std::size_t M> Vector<T,M> first() const {
+    template <int M> Vector<T,M> first() const {
         Vector<T,M> r;
         std::copy(begin(), begin() + M, r.begin());
         return r;
     }
 
     /// @brief Create a new Vector from the last M elements of this.
-    template <std::size_t M> Vector<T,M> last() const {
+    template <int M> Vector<T,M> last() const {
         Vector<T,M> r;
         std::copy(begin() + (N - M), begin() + N, r.begin());
         return r;
@@ -277,7 +277,7 @@ template <typename T>
 struct Vector<T,0> {
     VECTOR_TYPEDEFS
 
-    typedef boost::mpl::size_t<0> ND;
+    typedef boost::mpl::int_<0> ND;
 
     size_type size() const { return 0; }           ///< @brief Return the size of the Vector.
     size_type max_size() const { return 0; }       ///< @brief Return the size of the Vector.
@@ -314,18 +314,18 @@ struct Vector<T,0> {
     const_reference operator[](std::size_t i) const { NDARRAY_ASSERT(false); return 0; }
 
     /// @brief Create a new Vector that is a subset of this.
-    template <std::size_t Start, std::size_t Stop>
+    template <int Start, int Stop>
     Vector<T,Stop-Start> getRange() const {
         return Vector<T,Stop-Start>();
     }
 
     /// @brief Create a new Vector from the first M elements of this.
-    template <std::size_t M> Vector<T,M> first() const {
+    template <int M> Vector<T,M> first() const {
         return Vector<T,M>();
     }
 
     /// @brief Create a new Vector from the last M elements of this.
-    template <std::size_t M> Vector<T,M> last() const {
+    template <int M> Vector<T,M> last() const {
         return Vector<T,M>();
     }
 
@@ -368,7 +368,7 @@ struct Vector<T,0> {
 
 
 /// @brief Concatenate two Vectors into a single long Vector.
-template <typename T, std::size_t N, std::size_t M>
+template <typename T, int N, int M>
 inline Vector<T,N+M> concatenate(Vector<T,N> const & a, Vector<T,M> const & b) {
     Vector<T,N+M> r;
     std::copy(a.begin(),a.end(),r.begin());
@@ -377,7 +377,7 @@ inline Vector<T,N+M> concatenate(Vector<T,N> const & a, Vector<T,M> const & b) {
 } 
 
 /// @brief Return a new Vector with the given scalar appended to the original.
-template <typename T, std::size_t N>
+template <typename T, int N>
 inline Vector<T,N+1> concatenate(Vector<T,N> const & a, T const & b) {
     Vector<T,N+1> r;
     std::copy(a.begin(),a.end(),r.begin());
@@ -386,7 +386,7 @@ inline Vector<T,N+1> concatenate(Vector<T,N> const & a, T const & b) {
 }
 
 /// @brief Return a new Vector with the given scalar prepended to the original.
-template <typename T, std::size_t N>
+template <typename T, int N>
 inline Vector<T,N+1> concatenate(T const & a, Vector<T,N> const & b) {
     Vector<T,N+1> r;
     r[0] = a;
@@ -402,12 +402,12 @@ BOOST_PP_REPEAT_FROM_TO(1, NDARRAY_MAKE_VECTOR_MAX, NDARRAY_MAKE_VECTOR_SPEC, un
  *
  *  Defined for N in [0 - NDARRAY_MAKE_VECTOR_MAX).
  */
-template <typename T, std::size_t N>
+template <typename T, int N>
 Vector<T,N> makeVector(T v1, T v2, ..., T vN);
 #endif
 
 /** @brief Unary bitwise NOT for Vector. */
-template <typename T, std::size_t N>
+template <typename T, int N>
 inline Vector<T,N> operator~(Vector<T,N> const & vector) {
     Vector<T,N> r(vector);
     for (typename Vector<T,N>::Iterator i = r.begin(); i != r.end(); ++i) (*i) = ~(*i);
@@ -415,7 +415,7 @@ inline Vector<T,N> operator~(Vector<T,N> const & vector) {
 }
 
 /** @brief Unary negation for Vector. */
-template <typename T, std::size_t N>
+template <typename T, int N>
 inline Vector<T,N> operator!(Vector<T,N> const & vector) {
     Vector<T,N> r(vector);
     for (typename Vector<T,N>::Iterator i = r.begin(); i != r.end(); ++i) (*i) = !(*i);

--- a/include/ndarray/Vector.h.m4
+++ b/include/ndarray/Vector.h.m4
@@ -30,21 +30,21 @@ define(`VECTOR_ASSIGN',
 define(`VECTOR_BINARY_OP',
 `
     /// @brief Operator overload for Vector $1 Vector.
-    template <typename T, typename U, int N>
+    template <typename T, typename U, std::size_t N>
     Vector<typename Promote<T,U>::Type,N>
     operator $1(Vector<T,N> const & a, Vector<U,N> const & b) {
         Vector<typename Promote<T,U>::Type,N> r(a);
         return r $1= b;
     }
     /** @brief Operator overload for Vector $1 Scalar. */
-    template <typename T, typename U, int N>
+    template <typename T, typename U, std::size_t N>
     Vector<typename Promote<T,U>::Type,N>
     operator $1(Vector<T,N> const & a, U b) {
         Vector<typename Promote<T,U>::Type,N> r(a);
         return r $1= b;
     }
     /** @brief Operator overload for Scalar $1 Vector. */
-    template <typename T, typename U, int N>
+    template <typename T, typename U, std::size_t N>
     Vector<typename Promote<T,U>::Type,N>
     operator $1(U a, Vector<T,N> const & b) {
         Vector<typename Promote<T,U>::Type,N> r(a);
@@ -67,17 +67,19 @@ define(`VECTOR_TYPEDEFS',
     typedef boost::reverse_iterator<T*> reverse_iterator;
     typedef boost::reverse_iterator<const T*> const_reverse_iterator;
     typedef T * pointer;
-    typedef int difference_type;
-    typedef int size_type;
+    typedef std::ptrdiff_t difference_type;
+    typedef std::size_t size_type;
 ')dnl
 #ifndef NDARRAY_Vector_h_INCLUDED
 #define NDARRAY_Vector_h_INCLUDED
 
 /// @file ndarray/Vector.h Definition for Vector.
 
+#include <cstddef>
+
 #include <boost/iterator/reverse_iterator.hpp>
 #include <boost/utility/enable_if.hpp>
-#include <boost/mpl/int.hpp>
+#include <boost/mpl/size_t.hpp>
 #include <boost/preprocessor/repetition/repeat.hpp>
 #include <boost/preprocessor/repetition/repeat_from_to.hpp>
 #include <boost/preprocessor/repetition/enum.hpp>
@@ -114,7 +116,7 @@ namespace ndarray {
  *  @class Vector
  *  @brief A fixed-size 1D array class.
  *
- *  Vector (with T==int) is primarily used as the data
+ *  Vector (with T==std::size_t) is primarily used as the data
  *  type for the shape and strides attributes of Array.
  *  
  *  Vector is implemented almost exactly as a non-aggregate
@@ -123,15 +125,15 @@ namespace ndarray {
  */
 template <
     typename T, ///< Data type.
-    int N       ///< Number of elements.
+    std::size_t N       ///< Number of elements.
     >
 struct Vector {
     VECTOR_TYPEDEFS
 
-    typedef boost::mpl::int_<N> ND;
+    typedef boost::mpl::size_t<N> ND;
 
-    size_type size() const { return N; }           ///< @brief Return the size of the Vector.
-    size_type max_size() const { return N; }       ///< @brief Return the size of the Vector.
+    size_type size() const { return static_cast<size_type>(N); }           ///< @brief Return the size of the Vector.
+    size_type max_size() const { return static_cast<size_type>(N); }       ///< @brief Return the size of the Vector.
     bool empty() const { return N==0; }            ///< @brief Return true if size() == 0.
     /// @brief Return an iterator to the beginning of the Vector.
     iterator begin() { return elems; }
@@ -160,12 +162,12 @@ struct Vector {
     const_reference back() const { return *(elems+N-1); }
 
     /// @brief Return a reference to the element with the given index.
-    reference operator[](int i) { return elems[i]; }
+    reference operator[](std::size_t i) { return elems[i]; }
     /// @brief Return a const_reference to the element with the given index.
-    const_reference operator[](int i) const { return elems[i]; }
+    const_reference operator[](std::size_t i) const { return elems[i]; }
 
     /// @brief Create a new Vector that is a subset of this.
-    template <int Start, int Stop>
+    template <std::size_t Start, std::size_t Stop>
     Vector<T,Stop-Start> getRange() const {
         Vector<T,Stop-Start> r;
         std::copy(begin() + Start, begin()+Stop, r.begin());
@@ -173,14 +175,14 @@ struct Vector {
     }
 
     /// @brief Create a new Vector from the first M elements of this.
-    template <int M> Vector<T,M> first() const {
+    template <std::size_t M> Vector<T,M> first() const {
         Vector<T,M> r;
         std::copy(begin(), begin() + M, r.begin());
         return r;
     }
 
     /// @brief Create a new Vector from the last M elements of this.
-    template <int M> Vector<T,M> last() const {
+    template <std::size_t M> Vector<T,M> last() const {
         Vector<T,M> r;
         std::copy(begin() + (N - M), begin() + N, r.begin());
         return r;
@@ -271,7 +273,7 @@ template <typename T>
 struct Vector<T,0> {
     VECTOR_TYPEDEFS
 
-    typedef boost::mpl::int_<0> ND;
+    typedef boost::mpl::size_t<0> ND;
 
     size_type size() const { return 0; }           ///< @brief Return the size of the Vector.
     size_type max_size() const { return 0; }       ///< @brief Return the size of the Vector.
@@ -303,23 +305,23 @@ struct Vector<T,0> {
     const_reference back() const { NDARRAY_ASSERT(false); return 0; }
 
     /// @brief Return a reference to the element with the given index.
-    reference operator[](int i) { NDARRAY_ASSERT(false); return 0; }
+    reference operator[](std::size_t i) { NDARRAY_ASSERT(false); return 0; }
     /// @brief Return a const_reference to the element with the given index.
-    const_reference operator[](int i) const { NDARRAY_ASSERT(false); return 0; }
+    const_reference operator[](std::size_t i) const { NDARRAY_ASSERT(false); return 0; }
 
     /// @brief Create a new Vector that is a subset of this.
-    template <int Start, int Stop>
+    template <std::size_t Start, std::size_t Stop>
     Vector<T,Stop-Start> getRange() const {
         return Vector<T,Stop-Start>();
     }
 
     /// @brief Create a new Vector from the first M elements of this.
-    template <int M> Vector<T,M> first() const {
+    template <std::size_t M> Vector<T,M> first() const {
         return Vector<T,M>();
     }
 
     /// @brief Create a new Vector from the last M elements of this.
-    template <int M> Vector<T,M> last() const {
+    template <std::size_t M> Vector<T,M> last() const {
         return Vector<T,M>();
     }
 
@@ -362,16 +364,16 @@ struct Vector<T,0> {
 
 
 /// @brief Concatenate two Vectors into a single long Vector.
-template <typename T, int N, int M>
+template <typename T, std::size_t N, std::size_t M>
 inline Vector<T,N+M> concatenate(Vector<T,N> const & a, Vector<T,M> const & b) {
     Vector<T,N+M> r;
     std::copy(a.begin(),a.end(),r.begin());
     std::copy(b.begin(),b.end(),r.begin()+N);
     return r;
-}
+} 
 
 /// @brief Return a new Vector with the given scalar appended to the original.
-template <typename T, int N>
+template <typename T, std::size_t N>
 inline Vector<T,N+1> concatenate(Vector<T,N> const & a, T const & b) {
     Vector<T,N+1> r;
     std::copy(a.begin(),a.end(),r.begin());
@@ -380,7 +382,7 @@ inline Vector<T,N+1> concatenate(Vector<T,N> const & a, T const & b) {
 }
 
 /// @brief Return a new Vector with the given scalar prepended to the original.
-template <typename T, int N>
+template <typename T, std::size_t N>
 inline Vector<T,N+1> concatenate(T const & a, Vector<T,N> const & b) {
     Vector<T,N+1> r;
     r[0] = a;
@@ -396,12 +398,12 @@ BOOST_PP_REPEAT_FROM_TO(1, NDARRAY_MAKE_VECTOR_MAX, NDARRAY_MAKE_VECTOR_SPEC, un
  *
  *  Defined for N in [0 - NDARRAY_MAKE_VECTOR_MAX).
  */
-template <typename T, int N>
+template <typename T, std::size_t N>
 Vector<T,N> makeVector(T v1, T v2, ..., T vN);
 #endif
 
 /** @brief Unary bitwise NOT for Vector. */
-template <typename T, int N>
+template <typename T, std::size_t N>
 inline Vector<T,N> operator~(Vector<T,N> const & vector) {
     Vector<T,N> r(vector);
     for (typename Vector<T,N>::Iterator i = r.begin(); i != r.end(); ++i) (*i) = ~(*i);
@@ -409,7 +411,7 @@ inline Vector<T,N> operator~(Vector<T,N> const & vector) {
 }
 
 /** @brief Unary negation for Vector. */
-template <typename T, int N>
+template <typename T, std::size_t N>
 inline Vector<T,N> operator!(Vector<T,N> const & vector) {
     Vector<T,N> r(vector);
     for (typename Vector<T,N>::Iterator i = r.begin(); i != r.end(); ++i) (*i) = !(*i);

--- a/include/ndarray/Vector.h.m4
+++ b/include/ndarray/Vector.h.m4
@@ -219,7 +219,11 @@ struct Vector {
     /// @brief Converting copy constructor.
     template <typename U>
     explicit Vector(Vector<U,N> const & other) {
-        this->template operator=(other);
+        this->
+		#ifndef _MSC_VER
+		template 
+		#endif
+		operator=(other);
     }
 
     /// @brief Return true if elements of other are equal to the elements of this.

--- a/include/ndarray/Vector.h.m4
+++ b/include/ndarray/Vector.h.m4
@@ -198,12 +198,20 @@ struct Vector {
      *
      *  Initializes the elements to zero.
      */
-    Vector() { this->template operator=(0); }
+    Vector() { this->
+	#ifndef _MSC_VER
+	template 
+	#endif
+	operator=(0); }
 
     /// @brief Construct with copies of a scalar.
     template <typename U>
     explicit Vector(U scalar) {
-        this->template operator=(scalar);
+        this->
+		#ifndef _MSC_VER
+		template 
+		#endif
+		operator=(scalar);
     }
 
     /// @brief Converting copy constructor.

--- a/include/ndarray/bp/Vector.h
+++ b/include/ndarray/bp/Vector.h
@@ -17,7 +17,7 @@
 
 namespace ndarray {
 
-template <typename T, std::size_t N>
+template <typename T, int N>
 class ToBoostPython< Vector<T,N> > {
 public:
 
@@ -35,7 +35,7 @@ public:
 
 };
 
-template <typename T, std::size_t N>
+template <typename T, int N>
 class FromBoostPython< Vector<T,N> > {
 public:
 

--- a/include/ndarray/bp/Vector.h
+++ b/include/ndarray/bp/Vector.h
@@ -10,14 +10,14 @@
  */
 #ifndef NDARRAY_BP_Vector_h_INCLUDED
 #define NDARRAY_BP_Vector_h_INCLUDED
-
+#include <cstddef>
 #include "boost/python.hpp"
 #include "ndarray/Vector.h"
 #include "ndarray/bp_fwd.h"
 
 namespace ndarray {
 
-template <typename T, int N>
+template <typename T, std::size_t N>
 class ToBoostPython< Vector<T,N> > {
 public:
 
@@ -26,7 +26,7 @@ public:
     static boost::python::tuple apply(Vector<T,N> const & x) {
         boost::python::handle<> t(PyTuple_New(N));
         for (int n=0; n<N; ++n) {
-            boost::python::object item(x[n]);
+            boost::python::object item(x[static_cast<size_t>(n)]);
             Py_INCREF(item.ptr());
             PyTuple_SET_ITEM(t.get(), n, item.ptr());
         }
@@ -35,7 +35,7 @@ public:
 
 };
 
-template <typename T, int N>
+template <typename T, std::size_t N>
 class FromBoostPython< Vector<T,N> > {
 public:
 
@@ -62,7 +62,7 @@ public:
         }
         Vector<T,N> r;
         for (int n=0; n<N; ++n) {
-            r[n] = boost::python::extract<T>(t[n]);
+            r[static_cast<size_t>(n)] = boost::python::extract<T>(t[n]);
         }
         return r;
     }

--- a/include/ndarray/casts.h
+++ b/include/ndarray/casts.h
@@ -16,7 +16,8 @@
  *
  *  @brief Specialized casts for Array.
  */
-
+#include <cstddef>
+ 
 #include "ndarray/Array.h"
 #include "ndarray/ArrayRef.h"
 #include <boost/type_traits/add_const.hpp>
@@ -39,9 +40,9 @@ struct ComplexExtractor {
         >::type RealElement;
     typedef ArrayRef<RealElement,ND::value,0> Result;
     typedef detail::ArrayAccess<Result> Access;
-    typedef Vector<int,ND::value> Index;
+    typedef Vector<std::size_t,ND::value> Index;
 
-    static inline Result apply(Array_ const & array, int offset) {
+    static inline Result apply(Array_ const & array, std::size_t offset) {
         return Access::construct(
             reinterpret_cast<RealElement*>(array.getData()) + offset,
             Access::Core::create(array.getShape(), array.getStrides() * 2, array.getManager())
@@ -90,17 +91,17 @@ static_dimension_cast(Array<T,N,C> const & array) {
 template <int C_, typename T, int N, int C>
 Array<T,N,C_>
 dynamic_dimension_cast(Array<T,N,C> const & array) {
-    Vector<int,N> shape = array.getShape();
-    Vector<int,N> strides = array.getStrides();
+    Vector<std::size_t,N> shape = array.getShape();
+    Vector<std::size_t,N> strides = array.getStrides();
     if (C_ >= 0) {
-        int n = 1;
+        std::size_t n = 1;
         for (int i=1; i <= C_; ++i) {
-            if (strides[N-i] != n) return Array<T,N,C_>();
+            if (strides[static_cast<size_t>(N-i)] != n) return Array<T,N,C_>();
             n *= shape[N-i];
         }
     } else {
-        int n = 1;
-        for (int i=0; i < -C_; ++i) {
+        std::size_t n = 1;
+        for (std::size_t i=0; i < static_cast<size_t>(-C_); ++i) {
             if (strides[i] != n) return Array<T,N,C_>();
             n *= strides[i];
         }
@@ -138,12 +139,12 @@ flatten(Array<T,N,C> const & input) {
     typedef detail::ArrayAccess< ArrayRef<T,Nf,(C+Nf-N)> > Access;
     typedef typename Access::Core Core;
     BOOST_STATIC_ASSERT(C+Nf-N >= 1);
-    Vector<int,N> oldShape = input.getShape();
-    Vector<int,Nf> newShape = oldShape.template first<Nf>();
-    for (int n=Nf; n<N; ++n)
+    Vector<std::size_t,N> oldShape = input.getShape();
+    Vector<std::size_t,Nf> newShape = oldShape.template first<Nf>();
+    for (std::size_t n=static_cast<size_t>(Nf); n<static_cast<size_t>(N); ++n)
         newShape[Nf-1] *= oldShape[n];
-    Vector<int,Nf> newStrides = input.getStrides().template first<Nf>();
-    newStrides[Nf-1] = 1;
+    Vector<std::size_t,Nf> newStrides = input.getStrides().template first<Nf>();
+    newStrides[static_cast<size_t>(Nf-1)] = 1;
     return Access::construct(input.getData(), Core::create(newShape, newStrides, input.getManager()));
 }
 

--- a/include/ndarray/detail/BinaryOp.h
+++ b/include/ndarray/detail/BinaryOp.h
@@ -16,6 +16,7 @@
  *
  *  @brief Lazy binary expression templates.
  */
+#include <cstddef>
 
 #include "ndarray/ExpressionBase.h"
 #include "ndarray/vectorize.h"
@@ -96,7 +97,7 @@ public:
     typedef typename ExpressionTraits<Self>::Iterator Iterator;
     typedef typename ExpressionTraits<Self>::Value Value;
     typedef typename ExpressionTraits<Self>::Reference Reference;
-    typedef Vector<int,N> Index;
+    typedef Vector<std::size_t,N> Index;
     
     BinaryOpExpression(
         Operand1 const & operand1,
@@ -107,7 +108,7 @@ public:
         NDARRAY_ASSERT(_operand1.getShape() == _operand2.getShape());
     }
 
-    Reference operator[](int n) const {
+    Reference operator[](std::size_t n) const {
         return Reference(_operand1[n],_operand2[n],_functor);
     }
 
@@ -119,7 +120,7 @@ public:
         return Iterator(_operand1.end(),_operand2.end(),_functor);
     }
 
-    template <int P> int getSize() const {
+    template <int P> std::size_t getSize() const {
         return _operand1.template getSize<P>();
     }
 

--- a/include/ndarray/detail/Core.h
+++ b/include/ndarray/detail/Core.h
@@ -17,6 +17,8 @@
  * @brief Definitions for Core.
  */
 
+#include <cstddef>
+ 
 #include <boost/intrusive_ptr.hpp>
 #include <boost/mpl/int.hpp>
 #include "ndarray/Vector.h"
@@ -52,19 +54,19 @@ public:
     typedef boost::intrusive_ptr<Core const> ConstPtr; ///< const intrusive_ptr to Core
 
     /// @brief Create a Core::Ptr with the given shape, strides, and manager.
-    template <int M>
+    template <std::size_t M>
     static Ptr create(
-        Vector<int,M> const & shape,
-        Vector<int,M> const & strides, 
+        Vector<std::size_t,M> const & shape,
+        Vector<std::size_t,M> const & strides, 
         Manager::Ptr const & manager = Manager::Ptr()
     ) {
         return Ptr(new Core(shape, strides, manager), false);
     }        
 
     /// @brief Create a Core::Ptr with the given shape and manager with contiguous strides.
-    template <int M>
+    template <std::size_t M>
     static Ptr create(
-        Vector<int,M> const & shape,
+        Vector<std::size_t,M> const & shape,
         DataOrderEnum order,
         Manager::Ptr const & manager = Manager::Ptr()
     ) {
@@ -85,39 +87,39 @@ public:
     Ptr copy() const { return Ptr(new Core(*this)); }
 
     /// @brief Return the size of the Nth dimension.
-    int getSize() const { return _size; }
+    std::size_t getSize() const { return _size; }
 
     /// @brief Return the stride of the Nth dimension.
-    int getStride() const { return _stride; }
+    std::size_t getStride() const { return _stride; }
 
     /// @brief Set the size of the Nth dimension.
-    void setSize(int size) { _size = size; }
+    void setSize(std::size_t size) { _size = size; }
 
     /// @brief Set the stride of the Nth dimension.
-    void setStride(int stride) { _stride = stride; }
+    void setStride(std::size_t stride) { _stride = stride; }
 
     /// @brief Recursively compute the offset to an element.
     template <int M>
-    int computeOffset(Vector<int,M> const & index) const {
+    std::size_t computeOffset(Vector<std::size_t,M> const & index) const {
         return index[M-N] * this->getStride() + Super::computeOffset(index);
     }
 
     /// @brief Recursively fill a shape vector.
     template <int M>
-    void fillShape(Vector<int,M> & shape) const {
+    void fillShape(Vector<std::size_t,M> & shape) const {
         shape[M-N] = this->getSize();
         Super::fillShape(shape);
     }
 
     /// @brief Recursively fill a strides vector.
     template <int M>
-    void fillStrides(Vector<int,M> & strides) const {
+    void fillStrides(Vector<std::size_t,M> & strides) const {
         strides[M-N] = this->getStride();
         Super::fillStrides(strides);
     }
 
     /// @brief Recursively determine the total number of elements.
-    int getNumElements() const {
+    std::size_t getNumElements() const {
         return getSize() * Super::getNumElements();
     }
     
@@ -126,23 +128,23 @@ protected:
     // Explicit strides
     template <int M>
     Core (
-        Vector<int,M> const & shape,
-        Vector<int,M> const & strides, 
+        Vector<std::size_t,M> const & shape,
+        Vector<std::size_t,M> const & strides, 
         Manager::Ptr const & manager
     ) : Super(shape, strides, manager), _size(shape[M-N]), _stride(strides[M-N]) {}
 
     // Row-major strides
     template <int M>
     Core (
-        Vector<int,M> const & shape,
+        Vector<std::size_t,M> const & shape,
         Manager::Ptr const & manager
     ) : Super(shape, manager), _size(shape[M-N]), _stride(Super::getStride() * Super::getSize()) {}
 
     // Column-major strides
     template <int M>
     Core (
-        Vector<int,M> const & shape,
-        int stride,
+        Vector<std::size_t,M> const & shape,
+        std::size_t stride,
         Manager::Ptr const & manager
     ) : Super(shape, stride * shape[M-N], manager), _size(shape[M-N]), _stride(stride) {}
 
@@ -154,8 +156,8 @@ protected:
     Core(Core const & other) : Super(other), _size(other._size), _stride(other._stride) {}
 
 private:
-    int _size;
-    int _stride;
+    std::size_t _size;
+    std::size_t _stride;
 };
 
 /**
@@ -184,12 +186,12 @@ public:
 
     Ptr copy() const { return Ptr(new Core(*this)); }
 
-    int getSize() const { return 1; }
-    int getStride() const { return 1; }
+    std::size_t getSize() const { return 1; }
+    std::size_t getStride() const { return 1; }
 
     /// @brief Recursively compute the offset to an element.
     template <int M>
-    int computeOffset(Vector<int,M> const & index) const { return 0; }
+    std::size_t computeOffset(Vector<std::size_t,M> const & index) const { return 0; }
 
     /// @brief Return the Manager that determines the lifetime of the array data.
     Manager::Ptr getManager() const { return _manager; }
@@ -199,14 +201,14 @@ public:
 
     /// @brief Recursively fill a shape vector.
     template <int M>
-    void fillShape(Vector<int,M> const & shape) const {}
+    void fillShape(Vector<std::size_t,M> const & shape) const {}
 
     /// @brief Recursively fill a strides vector.
     template <int M>
-    void fillStrides(Vector<int,M> const & strides) const {}
+    void fillStrides(Vector<std::size_t,M> const & strides) const {}
 
     /// @brief Recursively determine the total number of elements.
-    int getNumElements() const { return 1; }
+    std::size_t getNumElements() const { return 1; }
 
     /// @brief Return the reference count (for debugging purposes).
     int getRC() const { return _rc; }
@@ -220,21 +222,21 @@ protected:
 
     template <int M>
     Core(
-        Vector<int,M> const & shape,
-        Vector<int,M> const & strides, 
+        Vector<std::size_t,M> const & shape,
+        Vector<std::size_t,M> const & strides, 
         Manager::Ptr const & manager
     ) : _manager(manager), _rc(1) {}
 
     template <int M>
     Core(
-        Vector<int,M> const & shape,
+        Vector<std::size_t,M> const & shape,
         Manager::Ptr const & manager
     ) : _manager(manager), _rc(1) {}
 
     template <int M>
     Core(
-        Vector<int,M> const & shape,
-        int stride,
+        Vector<std::size_t,M> const & shape,
+        std::size_t stride,
         Manager::Ptr const & manager
     ) : _manager(manager), _rc(1) {}
 

--- a/include/ndarray/detail/Core.h
+++ b/include/ndarray/detail/Core.h
@@ -54,7 +54,7 @@ public:
     typedef boost::intrusive_ptr<Core const> ConstPtr; ///< const intrusive_ptr to Core
 
     /// @brief Create a Core::Ptr with the given shape, strides, and manager.
-    template <std::size_t M>
+    template <int M>
     static Ptr create(
         Vector<std::size_t,M> const & shape,
         Vector<std::size_t,M> const & strides, 
@@ -64,7 +64,7 @@ public:
     }        
 
     /// @brief Create a Core::Ptr with the given shape and manager with contiguous strides.
-    template <std::size_t M>
+    template <int M>
     static Ptr create(
         Vector<std::size_t,M> const & shape,
         DataOrderEnum order,

--- a/include/ndarray/detail/NestedIterator.h
+++ b/include/ndarray/detail/NestedIterator.h
@@ -48,7 +48,7 @@ public:
     typedef typename ArrayTraits<T,N,C>::Value Value;
     typedef typename ArrayTraits<T,N,C>::Reference Reference;
     
-    Reference operator[](int n) const {
+    Reference operator[](std::size_t n) const {
         Reference r(_ref);
         r._data += n * _stride;
         return r;
@@ -60,7 +60,7 @@ public:
 
     NestedIterator() : _ref(Value()), _stride(0) {}
 
-    NestedIterator(Reference const & ref, int stride) : _ref(ref), _stride(stride) {}
+    NestedIterator(Reference const & ref, std::ptrdiff_t stride) : _ref(ref), _stride(stride) {}
 
     NestedIterator(NestedIterator const & other) : _ref(other._ref), _stride(other._stride) {}
 
@@ -94,10 +94,10 @@ private:
 
     void increment() { _ref._data += _stride; }
     void decrement() { _ref._data -= _stride; }
-    void advance(int n) { _ref._data += _stride * n; }
+    void advance(std::ptrdiff_t n) { _ref._data += _stride * n; }
 
     template <typename T_, int C_>
-    int distance_to(NestedIterator<T_,N,C_> const & other) const {
+    std::ptrdiff_t distance_to(NestedIterator<T_,N,C_> const & other) const {
         return std::distance(_ref._data, other._ref._data) / _stride; 
     }
 
@@ -107,7 +107,7 @@ private:
     }
 
     Reference _ref;
-    int _stride;
+    std::ptrdiff_t _stride;
 };
 
 } // namespace detail

--- a/include/ndarray/detail/StridedIterator.h
+++ b/include/ndarray/detail/StridedIterator.h
@@ -16,7 +16,8 @@
  *
  *  @brief Definition of StridedIterator.
  */
-
+#include <cstddef>
+ 
 #include "ndarray_fwd.h"
 #include <boost/iterator/iterator_facade.hpp>
 
@@ -40,7 +41,7 @@ public:
     
     StridedIterator() : _data(0), _stride(0) {}
 
-    StridedIterator(T * data, int stride) : _data(data), _stride(stride) {}
+    StridedIterator(T * data, std::ptrdiff_t stride) : _data(data), _stride(stride) {}
 
     StridedIterator(StridedIterator const & other) : _data(other._data), _stride(other._stride) {}
 
@@ -75,10 +76,10 @@ private:
 
     void increment() { _data += _stride; }
     void decrement() { _data -= _stride; }
-    void advance(int n) { _data += _stride * n; }
+    void advance(std::ptrdiff_t n) { _data += _stride * n; }
 
     template <typename U>
-    int distance_to(StridedIterator<U> const & other) const {
+    std::ptrdiff_t distance_to(StridedIterator<U> const & other) const {
         return std::distance(_data, other._data) / _stride; 
     }
 
@@ -88,7 +89,7 @@ private:
     }
 
     T * _data;
-    int _stride;
+    std::ptrdiff_t _stride;
 
 };
 

--- a/include/ndarray/detail/UnaryOp.h
+++ b/include/ndarray/detail/UnaryOp.h
@@ -16,7 +16,8 @@
  *
  *  @brief Lazy unary expression templates.
  */
-
+#include <cstddef>
+ 
 #include "ndarray/ExpressionBase.h"
 #include "ndarray/vectorize.h"
 #include <boost/iterator/iterator_adaptor.hpp>
@@ -79,12 +80,12 @@ public:
     typedef typename ExpressionTraits<Self>::Iterator Iterator;
     typedef typename ExpressionTraits<Self>::Value Value;
     typedef typename ExpressionTraits<Self>::Reference Reference;
-    typedef Vector<int,N> Index;
+    typedef Vector<std::size_t,N> Index;
     
     UnaryOpExpression(Operand const & operand, UnaryFunction const & functor) :
         _operand(operand), _functor(functor) {}
 
-    Reference operator[](int n) const {
+    Reference operator[](std::size_t n) const {
         return Reference(_operand[n],_functor);
     }
 
@@ -96,7 +97,7 @@ public:
         return Iterator(_operand.end(),_functor);
     }
 
-    template <int P> int getSize() const {
+    template <int P> std::size_t getSize() const {
         return _operand.template getSize<P>();
     }
 

--- a/include/ndarray/fft/FourierOps.h
+++ b/include/ndarray/fft/FourierOps.h
@@ -11,7 +11,7 @@
 #ifndef NDARRAY_FFT_FourierOps_h_INCLUDED
 #define NDARRAY_FFT_FourierOps_h_INCLUDED
 
-/** 
+/**
  *  @file ndarray/fft/FourierOps.h
  *
  *  @brief Common Fourier-space operations.
@@ -21,9 +21,16 @@
 
 #include "ndarray.h"
 
+
+
 namespace ndarray {
 /// \cond INTERNAL
 namespace detail {
+
+#ifdef _MSC_VER
+/** Portable double pi value. */
+static const double M_PI = 4. * atan(1.);
+#endif
 
 /**
  *  @internal @ingroup FFTndarrayInternalGroup
@@ -43,7 +50,7 @@ struct FourierOps {
         T u = -2.0 * M_PI * (*offset) / array.size();
         int kMid = (array.size() + 1) / 2;
         for (int k = 0; k < kMid; ++k, ++iter) {
-            FourierOps<T,N-1>::shift(offset+1, factor * std::polar(static_cast<T>(1), u * k), 
+            FourierOps<T,N-1>::shift(offset+1, factor * std::polar(static_cast<T>(1), u * k),
                                      *iter, real_last_dim);
         }
         if (array.size() % 2 == 0) {
@@ -85,7 +92,7 @@ struct FourierOps {
  */
 template <typename T>
 struct FourierOps<T,1> {
-    
+
     template <int C>
     static void shift(
         T const * offset,
@@ -117,7 +124,7 @@ struct FourierOps<T,1> {
         }
         if (real_last_dim % 2 == 0) {
             array[kMid] = static_cast<T>(0);
-        }            
+        }
     }
 
 };

--- a/include/ndarray/fft/FourierTransform.cc
+++ b/include/ndarray/fft/FourierTransform.cc
@@ -8,34 +8,47 @@
  * of the source distribution, or alternately available at:
  * https://github.com/ndarray/ndarray
  */
+#include <cstddef>
+#include <exception>
+#include <numeric>
 #include "ndarray/fft/FFTWTraits.h"
 #include "ndarray/fft/FourierTransform.h"
 
 namespace ndarray {
 
-template <typename T, int N> 
+template <typename T, int N>
 template <int M>
 Array<typename FourierTransform<T,N>::ElementX,M,M>
-FourierTransform<T,N>::initializeX(Vector<int,M> const & shape) {
-    OwnerX xOwner = detail::FFTWTraits<T>::allocateX(shape.product());
+FourierTransform<T,N>::initializeX(Vector<std::size_t,M> const & shape) {
+    if (shape.product() > std::numeric_limits<int>::max()) {
+      // fftw3 only supports int many elements.
+      throw std::exception();
+    }
+    OwnerX xOwner = detail::FFTWTraits<T>::allocateX(static_cast<int>(shape.product()));
+    if (xOwner.get() == nullptr) throw std::exception();
     return Array<ElementX,M,M>(external(xOwner.get(), shape, ROW_MAJOR, xOwner));
 }
 
-template <typename T, int N> 
+template <typename T, int N>
 template <int M>
 Array<typename FourierTransform<T,N>::ElementK,M,M>
-FourierTransform<T,N>::initializeK(Vector<int,M> const & shape) {
-    Vector<int,M> kShape(shape);
+FourierTransform<T,N>::initializeK(Vector<std::size_t,M> const & shape) {
+    Vector<std::size_t,M> kShape(shape);
     kShape[M-1] = detail::FourierTraits<T>::computeLastDimensionSize(shape[M-1]);
-    OwnerK kOwner = detail::FFTWTraits<T>::allocateK(kShape.product());
+    if (kShape.product() > std::numeric_limits<int>::max()) {
+      // fftw3 only supports int many elements.
+      throw std::exception();
+    }
+    OwnerK kOwner = detail::FFTWTraits<T>::allocateK(static_cast<int>(kShape.product()));
+    if (kOwner.get() == nullptr) throw std::exception();
     return Array<ElementK,M,M>(external(kOwner.get(), kShape, ROW_MAJOR, kOwner));
 }
 
-template <typename T, int N> 
+template <typename T, int N>
 template <int M>
 void
 FourierTransform<T,N>::initialize(
-    Vector<int,M> const & shape, 
+    Vector<std::size_t,M> const & shape,
     Array<ElementX,M,M> & x,
     Array<ElementK,M,M> & k
 ) {
@@ -45,22 +58,25 @@ FourierTransform<T,N>::initialize(
     NDARRAY_ASSERT(std::equal(shape.begin(), shape.end()-1, k.getShape().begin()));
 }
 
-template <typename T, int N> 
+template <typename T, int N>
 typename FourierTransform<T,N>::Ptr
 FourierTransform<T,N>::planForward(
-    Index const & shape, 
+    Index const & shape,
     typename FourierTransform<T,N>::ArrayX & x,
     typename FourierTransform<T,N>::ArrayK & k
 ) {
     initialize(shape,x,k);
-    return Ptr(
-        new FourierTransform(
-            detail::FFTWTraits<T>::forward(
-                N, shape.begin(), 1,
+    auto ftshape = ndarray::Vector<int, N>(shape);
+    void *fp = detail::FFTWTraits<T>::forward(
+                N, ftshape.begin(), 1,
                 x.getData(), NULL, 1, 0,
                 k.getData(), NULL, 1, 0,
-                FFTW_MEASURE | FFTW_DESTROY_INPUT
-            ),
+                FFTW_MEASURE | FFTW_DESTROY_INPUT);
+    if (fp == nullptr)
+      throw std::exception();
+    return Ptr(
+        new FourierTransform(
+            fp,
             x.getManager(),
             k.getManager()
         )
@@ -75,10 +91,11 @@ FourierTransform<T,N>::planInverse(
     typename FourierTransform<T,N>::ArrayX & x
 ) {
     initialize(shape,x,k);
+    auto ftshape = ndarray::Vector<int, N>(shape);
     return Ptr(
         new FourierTransform(
             detail::FFTWTraits<T>::inverse(
-                N, shape.begin(), 1,
+                N, ftshape.begin(), 1,
                 k.getData(), NULL, 1, 0,
                 x.getData(), NULL, 1, 0,
                 FFTW_MEASURE | FFTW_DESTROY_INPUT
@@ -97,21 +114,24 @@ FourierTransform<T,N>::planMultiplexForward(
     typename FourierTransform<T,N>::MultiplexArrayK & k
 ) {
     initialize(shape,x,k);
-    return Ptr(
-        new FourierTransform(
-            detail::FFTWTraits<T>::forward(
-                N, shape.begin()+1, shape[0],
+    auto ftshape = ndarray::Vector<int, N+1>(shape);
+    void *fp = detail::FFTWTraits<T>::forward(
+                N, ftshape.begin()+1, ftshape[0],
                 x.getData(), NULL, 1, x.template getStride<0>(),
                 k.getData(), NULL, 1, k.template getStride<0>(),
-                FFTW_MEASURE | FFTW_DESTROY_INPUT
-            ),
+                FFTW_MEASURE | FFTW_DESTROY_INPUT);
+    if (fp == nullptr)
+      throw std::exception();
+    return Ptr(
+        new FourierTransform(
+            fp,
             x.getManager(),
             k.getManager()
         )
     );
 }
 
-template <typename T, int N> 
+template <typename T, int N>
 typename FourierTransform<T,N>::Ptr
 FourierTransform<T,N>::planMultiplexInverse(
     MultiplexIndex const & shape,
@@ -119,10 +139,11 @@ FourierTransform<T,N>::planMultiplexInverse(
     typename FourierTransform<T,N>::MultiplexArrayX & x
 ) {
     initialize(shape,x,k);
+    auto ftshape = ndarray::Vector<int, N+1>(shape);
     return Ptr(
         new FourierTransform(
             detail::FFTWTraits<T>::inverse(
-                N, shape.begin()+1, shape[0],
+                N, ftshape.begin()+1, ftshape[0],
                 k.getData(), NULL, 1, k.template getStride<0>(),
                 x.getData(), NULL, 1, x.template getStride<0>(),
                 FFTW_MEASURE | FFTW_DESTROY_INPUT

--- a/include/ndarray/fft/FourierTransform.h
+++ b/include/ndarray/fft/FourierTransform.h
@@ -11,11 +11,13 @@
 #ifndef NDARRAY_FFT_FourierTransform_h_INCLUDED
 #define NDARRAY_FFT_FourierTransform_h_INCLUDED
 
-/** 
+/**
  *  @file ndarray/fft/FourierTransform.h
  *
  *  @brief Definitions for FourierTransform.
  */
+
+#include <cstddef>
 
 #include <boost/noncopyable.hpp>
 
@@ -42,22 +44,22 @@ template <typename T, int N>
 class FourierTransform : private boost::noncopyable {
     BOOST_STATIC_ASSERT((!boost::is_const<T>::value));
 public:
-    
+
     typedef boost::shared_ptr<FourierTransform> Ptr;
 
     typedef typename detail::FourierTraits<T>::ElementX ElementX; ///< Real-space array data type;
     typedef typename detail::FourierTraits<T>::ElementK ElementK; ///< Fourier-space array data type;
 
-    typedef Vector<int,N> Index; ///< Shape type for arrays.
+    typedef Vector<std::size_t,N> Index; ///< Shape type for arrays.
     typedef Array<ElementX,N,N> ArrayX; ///< Real-space array type.
     typedef Array<ElementK,N,N> ArrayK; ///< Fourier-space array type.
-    typedef Vector<int,N+1> MultiplexIndex; ///< Shape type for multiplexed arrays.
+    typedef Vector<std::size_t,N+1> MultiplexIndex; ///< Shape type for multiplexed arrays.
     typedef Array<ElementX,N+1,N+1> MultiplexArrayX; ///< Real-space multiplexed array type.
     typedef Array<ElementK,N+1,N+1> MultiplexArrayK; ///< Fourier-space multiplexed array type.
 
     /**
      *  @brief Create a plan for forward-transforming a single N-dimensional array.
-     *   
+     *
      *  Arrays will be initialized with new memory if empty.  If they are not empty,
      *  existing data may be overwritten when the plan is created.
      */
@@ -69,7 +71,7 @@ public:
 
     /**
      *  @brief Create a plan for inverse-transforming a single N-dimensional array.
-     *   
+     *
      *  Arrays will be initialized with new memory if empty.  If they are not empty,
      *  existing data may be overwritten when the plan is created.
      */
@@ -81,7 +83,7 @@ public:
 
     /**
      *  @brief Create a plan for forward-transforming a sequence of nested N-dimensional arrays.
-     *   
+     *
      *  Arrays will be initialized with new memory if empty.  If they are not empty,
      *  existing data may be overwritten when the plan is created.
      */
@@ -93,7 +95,7 @@ public:
 
     /**
      *  @brief Create a plan for inverse-transforming a sequence of nested N-dimensional arrays.
-     *   
+     *
      *  Arrays will be initialized with new memory if empty.  If they are not empty,
      *  existing data may be overwritten when the plan is created.
      */
@@ -105,26 +107,26 @@ public:
 
     /// @brief Create a new real-space array with the given real-space shape.
     template <int M>
-    static Array<ElementX,M,M> initializeX(Vector<int,M> const & shape);
+    static Array<ElementX,M,M> initializeX(Vector<std::size_t,M> const & shape);
 
     /// @brief Create a new Fourier-space array with the given real-space shape.
     template <int M>
-    static Array<ElementK,M,M> initializeK(Vector<int,M> const & shape);
+    static Array<ElementK,M,M> initializeK(Vector<std::size_t,M> const & shape);
 
-    /** 
+    /**
      *  @brief Initialize, as necessary, a pair of arrays with the given real-space shape.
-     * 
+     *
      *  If either array is not empty, it must be consistent with the given shape.
      */
     template <int M>
-    static void initialize(Vector<int,M> const & shape, Array<ElementX,M,M> & x, Array<ElementK,M,M> & k);
+    static void initialize(Vector<std::size_t,M> const & shape, Array<ElementX,M,M> & x, Array<ElementK,M,M> & k);
 
     /// @brief Execute the FFTW plan.
     void execute();
 
     ~FourierTransform();
 
-private:
+   private:
     typedef boost::shared_ptr<ElementX> OwnerX;
     typedef boost::shared_ptr<ElementK> OwnerK;
 

--- a/include/ndarray/formatting.h
+++ b/include/ndarray/formatting.h
@@ -63,7 +63,7 @@ public:
         detail::Formatter<Derived>::apply(*this,os,expr,0);
     }
 
-    template <typename Derived, int N> friend class detail::Formatter;
+    template <typename Derived, int N> friend struct detail::Formatter;
 };
 
 /// @brief Stream output for ExpressionBase using default-constructed FormatOptions.

--- a/include/ndarray/initialization.h
+++ b/include/ndarray/initialization.h
@@ -14,7 +14,7 @@
 /** 
  *  \file ndarray/initialization.h @brief Construction functions for array.
  */
-
+#include <cstddef>
 #include "ndarray/Array.h"
 #include "ndarray/ArrayRef.h"
 #include "ndarray/Manager.h"
@@ -50,15 +50,15 @@ public:
         typedef typename Access::Core Core;
         typedef typename Access::Element Element;
         DataOrderEnum order = (ExpressionTraits< Target >::RMC::value < 0) ? COLUMN_MAJOR : ROW_MAJOR;
-        int total = _shape.product();
+        std::size_t total = _shape.product();
         std::pair<Manager::Ptr,Element*> p = SimpleManager<Element>::allocate(total);
         return Access::construct(p.second, Core::create(_shape, order, p.first));
     }
 
-    explicit SimpleInitializer(Vector<int,N> const & shape) : _shape(shape) {}
+    explicit SimpleInitializer(Vector<std::size_t,N> const & shape) : _shape(shape) {}
 
 private:
-    Vector<int,N> _shape;
+    Vector<std::size_t,N> _shape;
 };
 
 template <typename T, int N, typename Owner>
@@ -79,16 +79,16 @@ public:
 
     ExternalInitializer(
         T * data, 
-        Vector<int,N> const & shape,
-        Vector<int,N> const & strides,
+        Vector<std::size_t,N> const & shape,
+        Vector<std::size_t,N> const & strides,
         Owner const & owner
     ) : _data(data), _owner(owner), _shape(shape), _strides(strides) {}
 
 private:
     T * _data;
     Owner _owner;
-    Vector<int,N> _shape;
-    Vector<int,N> _strides;
+    Vector<std::size_t,N> _shape;
+    Vector<std::size_t,N> _strides;
 };
 
 } // namespace detail
@@ -102,7 +102,7 @@ private:
  *  @returns A temporary object convertible to an Array with fully contiguous row-major strides.
  */
 template <int N>
-inline detail::SimpleInitializer<N> allocate(Vector<int,N> const & shape) {
+inline detail::SimpleInitializer<N> allocate(Vector<std::size_t,N> const & shape) {
     return detail::SimpleInitializer<N>(shape); 
 }
 
@@ -111,7 +111,7 @@ inline detail::SimpleInitializer<N> allocate(Vector<int,N> const & shape) {
  *
  *  @returns A temporary object convertible to an Array with fully contiguous row-major strides.
  */
-inline detail::SimpleInitializer<1> allocate(int n) {
+inline detail::SimpleInitializer<1> allocate(std::size_t n) {
     return detail::SimpleInitializer<1>(ndarray::makeVector(n)); 
 }
 
@@ -120,7 +120,7 @@ inline detail::SimpleInitializer<1> allocate(int n) {
  *
  *  @returns A temporary object convertible to an Array with fully contiguous row-major strides.
  */
-inline detail::SimpleInitializer<2> allocate(int n1, int n2) {
+inline detail::SimpleInitializer<2> allocate(std::size_t n1, std::size_t n2) {
     return detail::SimpleInitializer<2>(ndarray::makeVector(n1, n2)); 
 }
 
@@ -129,7 +129,7 @@ inline detail::SimpleInitializer<2> allocate(int n1, int n2) {
  *
  *  @returns A temporary object convertible to an Array with fully contiguous row-major strides.
  */
-inline detail::SimpleInitializer<3> allocate(int n1, int n2, int n3) {
+inline detail::SimpleInitializer<3> allocate(std::size_t n1, std::size_t n2, std::size_t n3) {
     return detail::SimpleInitializer<3>(ndarray::makeVector(n1, n2, n3)); 
 }
 
@@ -150,12 +150,12 @@ copy(ExpressionBase<Derived> const & expr) {
 
 /// @brief Compute row- or column-major strides for the given shape.
 template <int N>
-Vector<int,N> computeStrides(Vector<int,N> const & shape, DataOrderEnum order=ROW_MAJOR) {
-    Vector<int,N> r(1);
+Vector<std::size_t,N> computeStrides(Vector<std::size_t,N> const & shape, DataOrderEnum order=ROW_MAJOR) {
+    Vector<std::size_t,N> r(1);
     if (order == ROW_MAJOR) {
-        for (int n=N-1; n > 0; --n) r[n-1] = r[n] * shape[n];
+        for (std::size_t n=static_cast<size_t>(N-1); n > 0; --n) r[n-1] = r[n] * shape[n];
     } else {
-        for (int n=1; n < N; ++n) r[n] = r[n-1] * shape[n-1];
+        for (std::size_t n=1; n < static_cast<size_t>(N); ++n) r[n] = r[n-1] * shape[n-1];
     }
     return r;
 }
@@ -176,8 +176,8 @@ Vector<int,N> computeStrides(Vector<int,N> const & shape, DataOrderEnum order=RO
 template <typename T, int N, typename Owner>
 inline detail::ExternalInitializer<T,N,Owner> external(
     T * data,
-    Vector<int,N> const & shape,
-    Vector<int,N> const & strides,
+    Vector<std::size_t,N> const & shape,
+    Vector<std::size_t,N> const & strides,
     Owner const & owner
 ) {
     return detail::ExternalInitializer<T,N,Owner>(data, shape, strides, owner);
@@ -198,8 +198,8 @@ inline detail::ExternalInitializer<T,N,Owner> external(
 template <typename T, int N>
 inline detail::ExternalInitializer<T,N,detail::NullOwner> external(
     T * data,
-    Vector<int,N> const & shape,
-    Vector<int,N> const & strides
+    Vector<std::size_t,N> const & shape,
+    Vector<std::size_t,N> const & strides
 ) {
     return detail::ExternalInitializer<T,N,detail::NullOwner>(data, shape, strides, detail::NullOwner());
 }
@@ -220,7 +220,7 @@ inline detail::ExternalInitializer<T,N,detail::NullOwner> external(
 template <typename T, int N, typename Owner>
 inline detail::ExternalInitializer<T,N,Owner> external(
     T * data,
-    Vector<int,N> const & shape,
+    Vector<std::size_t,N> const & shape,
     DataOrderEnum order,
     Owner const & owner
 ) {
@@ -242,7 +242,7 @@ inline detail::ExternalInitializer<T,N,Owner> external(
 template <typename T, int N>
 inline detail::ExternalInitializer<T,N,detail::NullOwner> external(
     T * data,
-    Vector<int,N> const & shape,
+    Vector<std::size_t,N> const & shape,
     DataOrderEnum order = ROW_MAJOR
 ) {
     return detail::ExternalInitializer<T,N,detail::NullOwner>(
@@ -253,7 +253,7 @@ inline detail::ExternalInitializer<T,N,detail::NullOwner> external(
 /// @}
 
 template <typename T, int N, int C>
-Array<T,N,C>::Array(int n1, int n2, int n3, int n4, int n5, int n6, int n7, int n8)
+Array<T,N,C>::Array(std::size_t n1, std::size_t n2, std::size_t n3, std::size_t n4, std::size_t n5, std::size_t n6, std::size_t n7, std::size_t n8)
     : Super(0, CorePtr())
 {
     typename Super::Index shape;
@@ -269,7 +269,7 @@ Array<T,N,C>::Array(int n1, int n2, int n3, int n4, int n5, int n6, int n7, int 
 }
 
 template <typename T, int N, int C>
-ArrayRef<T,N,C>::ArrayRef(int n1, int n2, int n3, int n4, int n5, int n6, int n7, int n8)
+ArrayRef<T,N,C>::ArrayRef(std::size_t n1, std::size_t n2, std::size_t n3, std::size_t n4, std::size_t n5, std::size_t n6, std::size_t n7, std::size_t n8)
     : Super(Array<T,N,C>(n1, n2, n3, n4, n5, n6, n7, n8))
 {}
 

--- a/include/ndarray/swig/numpy.h
+++ b/include/ndarray/swig/numpy.h
@@ -48,10 +48,11 @@ template <> struct NumpyTraits<npy_ubyte> { static int getCode() { return NPY_UB
 template <> struct NumpyTraits<npy_byte> { static int getCode() { return NPY_BYTE; } };
 template <> struct NumpyTraits<npy_ushort> { static int getCode() { return NPY_USHORT; } };
 template <> struct NumpyTraits<npy_short> { static int getCode() { return NPY_SHORT; } };
-// NPY_INT is a virtual flag that is never actually used. It must be
+// NPY_INT is on Windows a virtual flag that is never actually used. It must be
 // checked against the platform dtype.
 // see http://mail.scipy.org/pipermail/numpy-discussion/2010-June/051057.html.
 template <> struct NumpyTraits<npy_uint> { static int getCode() {
+#ifdef _MSC_VER
   switch(sizeof(int)) {
     case 1: return NPY_UBYTE;
     case 2: return NPY_USHORT;
@@ -59,9 +60,13 @@ template <> struct NumpyTraits<npy_uint> { static int getCode() {
     case 8: return NPY_ULONGLONG;
     // no datatype here...
     default: throw std::exception();
-}
+  }
+#else
+  return NPY_UINT;
+#endif
 }};
 template <> struct NumpyTraits<npy_int> { static int getCode() {
+#ifdef _MSC_VER
   switch(sizeof(int)) {
     case 1: return NPY_BYTE;
     case 2: return NPY_SHORT;
@@ -69,7 +74,10 @@ template <> struct NumpyTraits<npy_int> { static int getCode() {
     case 8: return NPY_LONGLONG;
     // no datatype here...
     default: throw std::exception();
-}
+  }
+#else
+  return NPY_INT;
+#endif
 }};
 template <> struct NumpyTraits<npy_ulong> { static int getCode() { return NPY_ULONG; } };
 template <> struct NumpyTraits<npy_long> { static int getCode() { return NPY_LONG; } };

--- a/include/ndarray/views.h
+++ b/include/ndarray/views.h
@@ -15,6 +15,8 @@
  *  \file ndarray/views.h @brief Public interface for arbitrary views into arrays.
  */
 
+#include <cstddef>
+ 
 #include <boost/fusion/include/push_back.hpp>
 #include <boost/fusion/include/vector.hpp>
 #include <boost/fusion/include/make_vector.hpp>
@@ -27,23 +29,23 @@ namespace index {
  *  @brief Simple structure defining a noncontiguous range of indices.
  */
 struct Slice {
-    int start;
-    int stop;
-    int step;
+    std::size_t start;
+    std::size_t stop;
+    std::size_t step;
 
-    Slice(int start_, int stop_, int step_) : start(start_), stop(stop_), step(step_) {}
+    Slice(std::size_t start_, std::size_t stop_, std::size_t step_) : start(start_), stop(stop_), step(step_) {}
 
-    int computeSize() const { return (step > 1) ? (stop - start + 1) / step : stop - start; }
+    std::size_t computeSize() const { return (step > 1) ? (stop - start + 1) / step : stop - start; }
 };
 
 /**
  *  @brief Simple structure defining a contiguous range of indices.
  */
 struct Range {
-    int start;
-    int stop;
+    std::size_t start;
+    std::size_t stop;
 
-    Range(int start_, int stop_) : start(start_), stop(stop_) {}
+    Range(std::size_t start_, std::size_t stop_) : start(start_), stop(stop_) {}
 };
 
 /**
@@ -55,9 +57,9 @@ struct Full {};
  *  @brief Structure marking a single element of a dimension.
  */
 struct Scalar {
-    int n;
+    std::size_t n;
 
-    explicit Scalar(int n_) : n(n_) {}
+    explicit Scalar(std::size_t n_) : n(n_) {}
 };
 
 } // namespace index
@@ -97,17 +99,17 @@ struct View {
     Full operator()() const { return Full(boost::fusion::push_back(_seq, index::Full())); }
     
     /// @brief Chain a contiguous range of the next dimension to this.
-    Range operator()(int start, int stop) const {
+    Range operator()(std::size_t start, std::size_t stop) const {
         return Range(boost::fusion::push_back(_seq, index::Range(start, stop)));
     }
 
     /// @brief Chain a noncontiguous slice of the next dimension to this.
-    Slice operator()(int start, int stop, int step) const {
+    Slice operator()(std::size_t start, std::size_t stop, std::size_t step) const {
         return Slice(boost::fusion::push_back(_seq, index::Slice(start, stop, step)));
     }
 
     /// @brief Chain a single element of the next dimension to this.
-    Scalar operator()(int n) const {
+    Scalar operator()(std::size_t n) const {
         return Scalar(boost::fusion::push_back(_seq, index::Scalar(n)));
     }
 };
@@ -123,21 +125,21 @@ inline View< boost::fusion::vector1<index::Full> > view() {
 }
 
 /** @brief Start a view definition that selects a contiguous range in the first dimension. */
-inline View< boost::fusion::vector1<index::Range> > view(int start, int stop) {
+inline View< boost::fusion::vector1<index::Range> > view(std::size_t start, std::size_t stop) {
     return View< boost::fusion::vector1<index::Range> >(
         boost::fusion::make_vector(index::Range(start, stop))
     );
 }
 
 /** @brief Start a view definition that selects a noncontiguous slice of the first dimension. */
-inline View< boost::fusion::vector1<index::Slice> > view(int start, int stop, int step) {
+inline View< boost::fusion::vector1<index::Slice> > view(std::size_t start, std::size_t stop, std::size_t step) {
     return View< boost::fusion::vector1<index::Slice> >(
         boost::fusion::make_vector(index::Slice(start, stop, step))
     );
 }
 
 /** @brief Start a view definition that selects single element from the first dimension. */
-inline View< boost::fusion::vector1<index::Scalar> > view(int n) {
+inline View< boost::fusion::vector1<index::Scalar> > view(std::size_t n) {
     return View< boost::fusion::vector1<index::Scalar> >(
         boost::fusion::make_vector(index::Scalar(n))
     );

--- a/include/ndarray_fwd.h
+++ b/include/ndarray_fwd.h
@@ -25,6 +25,8 @@
 
 /// @internal \defgroup ndarrayInternalGroup Internals
 
+#include <cstddef>
+
 #include <boost/type_traits/is_const.hpp>
 #include <boost/type_traits/add_const.hpp>
 #include <boost/type_traits/remove_const.hpp>
@@ -97,7 +99,7 @@ template <typename Derived> class ExpressionBase;
 template <typename Derived> class ArrayBase;
 template <typename T, int N, int C=0> class ArrayRef;
 template <typename T, int N, int C=0> class Array;
-template <typename T, int N> struct Vector;
+template <typename T, std::size_t N> struct Vector;
 
 } // namespace ndarray
 

--- a/include/ndarray_fwd.h
+++ b/include/ndarray_fwd.h
@@ -99,7 +99,7 @@ template <typename Derived> class ExpressionBase;
 template <typename Derived> class ArrayBase;
 template <typename T, int N, int C=0> class ArrayRef;
 template <typename T, int N, int C=0> class Array;
-template <typename T, std::size_t N> struct Vector;
+template <typename T, int N> struct Vector;
 
 } // namespace ndarray
 

--- a/tests/SConscript
+++ b/tests/SConscript
@@ -16,7 +16,7 @@ def RunBinaryUnitTest(target, source, env):
         env.Execute(Touch(target))
 
 def BinaryUnitTest(env, source, dependencies=None):
-    bin = env.Program(source)
+    bin = env.Program(target="%s.test" % source, source=source)
     run = env.Command(".%s.succeeded" % str(source), bin, RunBinaryUnitTest)
     if dependencies:
         env.Depends(run, dependencies)

--- a/tests/SConscript
+++ b/tests/SConscript
@@ -8,6 +8,7 @@
 #  of the source distribution, or alternately available at:
 #  https://github.com/ndarray/ndarray
 #
+import os
 import sys
 
 def RunBinaryUnitTest(target, source, env):
@@ -40,14 +41,23 @@ if testEnv.haveBoostTest:
         BinaryUnitTest(testEnv, "ndarray-eigen.cc")
     if testEnv.haveFFTW:
         fftwEnv = testEnv.Clone()
-        fftwEnv.Append(LIBS=["fftw3"])
         BinaryUnitTest(fftwEnv, "ndarray-fft.cc")
 
 if pyEnv.havePython:
     mod = pyEnv.LoadableModule("python_test_mod", "python_test_mod.cc", SHLIBPREFIX="")
+    if os.name == 'nt':
+        # Move the module to have the correct name.
+        mod = env.Command(os.path.join(Dir('.').srcnode().abspath, "python_test_mod.pyd"),
+                          mod,
+                          Move(os.path.join(Dir('.').srcnode().abspath, "python_test_mod.pyd"), mod[0]))
     PythonUnitTest(pyEnv, "python_test.py", mod)
     if pyEnv.haveSwig and pyEnv.haveEigen:
         mod = pyEnv.LoadableModule("_swig_test_mod", ["swig_test_mod.i"], SHLIBPREFIX="")
+        if os.name == 'nt':
+            # Move the module to have the correct name.
+            mod = env.Command(os.path.join(Dir('.').srcnode().abspath, "_swig_test_mod.pyd"),
+                              mod,
+                              Move(os.path.join(Dir('.').srcnode().abspath, "_swig_test_mod.pyd"), mod[0]))
         PythonUnitTest(pyEnv, "swig_test.py", mod)
 
 if bpEnv.haveBoostPython:
@@ -57,12 +67,22 @@ if bpEnv.haveBoostPython:
     bpEnv.Append( LINKFLAGS = ["$__RPATH"] )  # workaround for SCons bug #1644
     mod = bpEnv.LoadableModule("bp_test_mod", "bp_test_mod.cc", SHLIBPREFIX="",
                                LIBS=libs, LIBPATH=libpath, RPATH=rpath)
+    if os.name == 'nt':
+        # Move the module to have the correct name.
+        mod = env.Command(os.path.join(Dir('.').srcnode().abspath, "bp_test_mod.pyd"),
+                          mod,
+                          Move(os.path.join(Dir('.').srcnode().abspath, "bp_test_mod.pyd"), mod[0]))
     PythonUnitTest(bpEnv, "bp_test.py", mod)
     if bpEnv.haveEigen:
         mod = bpEnv.LoadableModule("eigen_bp_test_mod", "eigen_bp_test_mod.cc", SHLIBPREFIX="",
                                    LIBS=libs, LIBPATH=libpath, RPATH=rpath)
+        if os.name == 'nt':
+            # Move the module to have the correct name.
+            mod = env.Command(os.path.join(Dir('.').srcnode().abspath, "eigen_bp_test_mod.pyd"),
+                              mod,
+                              Move(os.path.join(Dir('.').srcnode().abspath, "eigen_bp_test_mod.pyd"), mod[0]))
         PythonUnitTest(bpEnv, "eigen_bp_test.py", mod)
-        
+
 
 env.Clean("tests", Glob("*.os"))
 env.Clean("tests", Glob("*.pyc"))

--- a/tests/SConscript
+++ b/tests/SConscript
@@ -16,7 +16,10 @@ def RunBinaryUnitTest(target, source, env):
         env.Execute(Touch(target))
 
 def BinaryUnitTest(env, source, dependencies=None):
-    bin = env.Program(target="%s.test" % source, source=source)
+    if os.name != 'nt':
+		bin = env.Program(target="%s.test" % source, source=source)
+    else:
+        bin = env.Program(source)
     run = env.Command(".%s.succeeded" % str(source), bin, RunBinaryUnitTest)
     if dependencies:
         env.Depends(run, dependencies)

--- a/tests/bp_test_mod.cc
+++ b/tests/bp_test_mod.cc
@@ -8,6 +8,7 @@
  * of the source distribution, or alternately available at:
  * https://github.com/ndarray/ndarray
  */
+#include <cstddef>
 
 #include "ndarray/bp/auto.h"
 
@@ -18,7 +19,7 @@ static boost::mt19937 engine;
 static boost::uniform_int<> random_int(2, 5);
 
 template <typename T, int N, int C>
-ndarray::Array<T,N,C> makeArray(ndarray::Vector<int,N> const & shape) {
+ndarray::Array<T,N,C> makeArray(ndarray::Vector<std::size_t,N> const & shape) {
     ndarray::Array<typename boost::remove_const<T>::type,N,N> a = ndarray::allocate(shape);
     ndarray::Array<typename boost::remove_const<T>::type,1,1> flat = ndarray::flatten<1>(a);
     for (int n=0; n < flat.template getSize<0>(); ++n) {
@@ -27,11 +28,11 @@ ndarray::Array<T,N,C> makeArray(ndarray::Vector<int,N> const & shape) {
     return a;
 }
 
-template <int N>
-ndarray::Vector<int,N> makeShape() {
-    ndarray::Vector<int,N> shape;
-    for (int n=0; n<N; ++n) {
-        shape[n] = random_int(engine);
+template <std::size_t N>
+ndarray::Vector<std::size_t,N> makeShape() {
+    ndarray::Vector<std::size_t,N> shape;
+    for (std::size_t n=0; n<N; ++n) {
+        shape[n] = static_cast<std::size_t>(random_int(engine));
     }
     return shape;
 }

--- a/tests/ndarray-fft.cc
+++ b/tests/ndarray-fft.cc
@@ -8,6 +8,7 @@
  * of the source distribution, or alternately available at:
  * https://github.com/ndarray/ndarray
  */
+#include <cstddef>
 #include <ndarray/fft.h>
 
 #define BOOST_TEST_DYN_LINK
@@ -21,7 +22,7 @@
 template <typename Derived1, typename Derived2>
 static boost::test_tools::predicate_result
 compareRelative(
-    ndarray::ExpressionBase<Derived1> const & a, 
+    ndarray::ExpressionBase<Derived1> const & a,
     ndarray::ExpressionBase<Derived2> const & b,
     double tolerance = 1E-4
 ) {
@@ -54,8 +55,8 @@ struct FourierTransformTester {
     typedef ndarray::FourierTransform<T,N> FFT;
 
     static void testSingle(
-        typename FFT::Index const & shape, 
-        typename FFT::ElementX const * xData, 
+        typename FFT::Index const & shape,
+        typename FFT::ElementX const * xData,
         typename FFT::ElementK const * kData
     ) {
         typename FFT::ArrayX xIn = FFT::initializeX(shape);
@@ -76,8 +77,8 @@ struct FourierTransformTester {
     }
 
     static void testMultiplex(
-        typename FFT::MultiplexIndex const & shape, 
-        typename FFT::ElementX const * xData, 
+        typename FFT::MultiplexIndex const & shape,
+        typename FFT::ElementX const * xData,
         typename FFT::ElementK const * kData
     ) {
         typename FFT::MultiplexArrayX xIn = FFT::initializeX(shape);
@@ -101,11 +102,11 @@ struct FourierTransformTester {
 BOOST_AUTO_TEST_CASE(real_1d) {
     double xData1[] = { -0.28131077, -0.25505012, -0.35444799,  1.77553825,  1.655009 };
     std::complex<double> kData1[] = {
-        std::complex<double>(2.53973837,0.0), 
+        std::complex<double>(2.53973837,0.0),
         std::complex<double>(-0.99838585,3.06854867),
         std::complex<double>(-0.97476025,-0.90303271)
     };
-    FourierTransformTester<double,1>::testSingle(ndarray::makeVector(5),xData1,kData1);
+    FourierTransformTester<double,1>::testSingle(ndarray::makeVector<std::size_t>(5),xData1,kData1);
     double xData2[] = { -0.42299104, 0.12242535, 0.37497334, 0.47846245, 1.19236641, -1.54989674 };
     std::complex<double> kData2[] = {
         std::complex<double>(0.19533977,0.00000000),
@@ -113,7 +114,7 @@ BOOST_AUTO_TEST_CASE(real_1d) {
         std::complex<double>(-0.01446277,-2.15615658),
         std::complex<double>(2.09335764,0.00000000),
     };
-    FourierTransformTester<double,1>::testSingle(ndarray::makeVector(6),xData2,kData2);
+    FourierTransformTester<double,1>::testSingle(ndarray::makeVector<std::size_t>(6),xData2,kData2);
     double xData3[] = {
         1.23233014,  0.80816934, -0.89026449,  0.64365113, -0.95490008,
         -2.31806551,  0.91599268,  0.48157162, -0.3389141 ,  1.3208367 ,
@@ -130,7 +131,7 @@ BOOST_AUTO_TEST_CASE(real_1d) {
         std::complex<double>(1.88429912,-1.97237400),
         std::complex<double>(-0.76453557,-0.09069146),
     };
-    FourierTransformTester<double,1>::testMultiplex(ndarray::makeVector(3,5),xData3,kData3);
+    FourierTransformTester<double,1>::testMultiplex(ndarray::makeVector<std::size_t>(3,5),xData3,kData3);
     double xData4[] = {
         0.20943609, -0.70119705, -0.04658762, -0.31573777,  0.0884646 ,
         -0.53593713, -1.43900058, -0.60146942, -0.90063027, -1.85456039,
@@ -151,7 +152,7 @@ BOOST_AUTO_TEST_CASE(real_1d) {
         std::complex<double>(-1.57064806,-2.97686989),
         std::complex<double>(-1.70918113,0.00000000),
     };
-    FourierTransformTester<double,1>::testMultiplex(ndarray::makeVector(3,6),xData4,kData4);
+    FourierTransformTester<double,1>::testMultiplex(ndarray::makeVector<std::size_t>(3,6),xData4,kData4);
 }
 
 BOOST_AUTO_TEST_CASE(complex_1d) {
@@ -169,7 +170,7 @@ BOOST_AUTO_TEST_CASE(complex_1d) {
         std::complex<double>(-4.75954620,1.77512198),
         std::complex<double>(0.56926906,-1.52257831),
     };
-    FourierTransformTester<std::complex<double>,1>::testSingle(ndarray::makeVector(5),xData1,kData1);
+    FourierTransformTester<std::complex<double>,1>::testSingle(ndarray::makeVector<std::size_t>(5),xData1,kData1);
     std::complex<double> xData2[] = {
         std::complex<double>(1.11465199,0.04081224),
         std::complex<double>(-1.08053999,0.78927525),
@@ -204,7 +205,7 @@ BOOST_AUTO_TEST_CASE(complex_1d) {
         std::complex<double>(4.27447257,1.85030986),
         std::complex<double>(-0.74625074,-1.07986528),
     };
-    FourierTransformTester<std::complex<double>,1>::testMultiplex(ndarray::makeVector(3,5),xData2,kData2);
+    FourierTransformTester<std::complex<double>,1>::testMultiplex(ndarray::makeVector<std::size_t>(3,5),xData2,kData2);
 }
 
 BOOST_AUTO_TEST_CASE(real_2d) {
@@ -224,7 +225,7 @@ BOOST_AUTO_TEST_CASE(real_2d) {
         std::complex<double>(1.39542736,-4.26784629),
         std::complex<double>(-0.37466977,1.23205340),
     };
-    FourierTransformTester<double,2>::testSingle(ndarray::makeVector(3,4),xData1,kData1);
+    FourierTransformTester<double,2>::testSingle(ndarray::makeVector<std::size_t>(3,4),xData1,kData1);
     double xData2[] = {
         0.61726814,  1.02478783,  1.05838231, -0.54398019, -0.22777548,
         -0.52546761, -0.82971628,  1.95616799,  1.9787389 , -0.5170171 ,
@@ -241,7 +242,7 @@ BOOST_AUTO_TEST_CASE(real_2d) {
         std::complex<double>(4.10890818,-5.68718353),
         std::complex<double>(2.56065709,1.51657561),
     };
-    FourierTransformTester<double,2>::testSingle(ndarray::makeVector(3,5),xData2,kData2);
+    FourierTransformTester<double,2>::testSingle(ndarray::makeVector<std::size_t>(3,5),xData2,kData2);
     double xData3[] = {
         -1.40706583, -0.10390223,  1.06058569, -0.31086132,  1.05681052,
         0.51060026,  0.94256284, -2.12855291, -0.44127652, -1.68077709,
@@ -281,7 +282,7 @@ BOOST_AUTO_TEST_CASE(real_2d) {
         std::complex<double>(2.40549637,0.26293493),
         std::complex<double>(3.09482501,2.74095257),
     };
-    FourierTransformTester<double,2>::testMultiplex(ndarray::makeVector(3,3,4),xData3,kData3);
+    FourierTransformTester<double,2>::testMultiplex(ndarray::makeVector<std::size_t>(3,3,4),xData3,kData3);
     double xData4[] = {
         -2.02786312, -0.3539932 ,  0.55001132,  0.88336882,  0.43662574,
         2.01541172, -0.84654528,  0.01492169,  0.25803824, -0.94068415,
@@ -322,7 +323,7 @@ BOOST_AUTO_TEST_CASE(real_2d) {
         std::complex<double>(-1.21120542,2.39435110),
         std::complex<double>(-2.03462006,0.80292460),
     };
-    FourierTransformTester<double,2>::testMultiplex(ndarray::makeVector(3,3,5),xData4,kData4);
+    FourierTransformTester<double,2>::testMultiplex(ndarray::makeVector<std::size_t>(3,3,5),xData4,kData4);
 }
 
 BOOST_AUTO_TEST_CASE(complex_2d) {
@@ -354,7 +355,7 @@ BOOST_AUTO_TEST_CASE(complex_2d) {
         std::complex<double>(-4.73536776,0.93369296),
         std::complex<double>(-2.82895659,-5.93210699),
     };
-    FourierTransformTester<std::complex<double>,2>::testSingle(ndarray::makeVector(3,4),xData1,kData1);
+    FourierTransformTester<std::complex<double>,2>::testSingle(ndarray::makeVector<std::size_t>(3,4),xData1,kData1);
     std::complex<double> xData2[] = {
         std::complex<double>(0.19529047,1.20435172),
         std::complex<double>(1.45906066,-0.97965946),
@@ -431,7 +432,7 @@ BOOST_AUTO_TEST_CASE(complex_2d) {
         std::complex<double>(3.38827586,-3.57929124),
         std::complex<double>(-1.57540539,-1.99610520),
     };
-    FourierTransformTester<std::complex<double>,2>::testMultiplex(ndarray::makeVector(3,3,4),xData2,kData2);
+    FourierTransformTester<std::complex<double>,2>::testMultiplex(ndarray::makeVector<std::size_t>(3,3,4),xData2,kData2);
 };
 
 template <typename T, int N>
@@ -504,19 +505,19 @@ struct FourierOpsTester<T,0> {
 };
 
 BOOST_AUTO_TEST_CASE(ops) {
-    FourierOpsTester<double,1>::testShift(ndarray::makeVector(256),ndarray::makeVector(7.25),10.0);
-    FourierOpsTester<double,1>::testShift(ndarray::makeVector(255),ndarray::makeVector(7.25),10.0);
-    FourierOpsTester<double,2>::testShift(ndarray::makeVector(256,256),ndarray::makeVector(7.25,6.4),10.0);
-    FourierOpsTester<double,2>::testShift(ndarray::makeVector(256,255),ndarray::makeVector(7.25,6.4),10.0);
+    FourierOpsTester<double,1>::testShift(ndarray::makeVector<std::size_t>(256),ndarray::makeVector(7.25),10.0);
+    FourierOpsTester<double,1>::testShift(ndarray::makeVector<std::size_t>(255),ndarray::makeVector(7.25),10.0);
+    FourierOpsTester<double,2>::testShift(ndarray::makeVector<std::size_t>(256,256),ndarray::makeVector(7.25,6.4),10.0);
+    FourierOpsTester<double,2>::testShift(ndarray::makeVector<std::size_t>(256,255),ndarray::makeVector(7.25,6.4),10.0);
 
-    FourierOpsTester<double,1>::testDifferentiate(ndarray::makeVector(256),10.0,0);
-    FourierOpsTester<double,1>::testDifferentiate(ndarray::makeVector(256),10.0,1);
-    FourierOpsTester<double,1>::testDifferentiate(ndarray::makeVector(255),10.0,0);
-    FourierOpsTester<double,1>::testDifferentiate(ndarray::makeVector(255),10.0,1);
-    FourierOpsTester<double,2>::testDifferentiate(ndarray::makeVector(256,256),10.0,0);
-    FourierOpsTester<double,2>::testDifferentiate(ndarray::makeVector(256,256),10.0,1);
-    FourierOpsTester<double,2>::testDifferentiate(ndarray::makeVector(256,255),10.0,0);
-    FourierOpsTester<double,2>::testDifferentiate(ndarray::makeVector(256,255),10.0,1);
+    FourierOpsTester<double,1>::testDifferentiate(ndarray::makeVector<std::size_t>(256),10.0,0);
+    FourierOpsTester<double,1>::testDifferentiate(ndarray::makeVector<std::size_t>(256),10.0,1);
+    FourierOpsTester<double,1>::testDifferentiate(ndarray::makeVector<std::size_t>(255),10.0,0);
+    FourierOpsTester<double,1>::testDifferentiate(ndarray::makeVector<std::size_t>(255),10.0,1);
+    FourierOpsTester<double,2>::testDifferentiate(ndarray::makeVector<std::size_t>(256,256),10.0,0);
+    FourierOpsTester<double,2>::testDifferentiate(ndarray::makeVector<std::size_t>(256,256),10.0,1);
+    FourierOpsTester<double,2>::testDifferentiate(ndarray::makeVector<std::size_t>(256,255),10.0,0);
+    FourierOpsTester<double,2>::testDifferentiate(ndarray::makeVector<std::size_t>(256,255),10.0,1);
 }
 
 #else

--- a/tests/ndarray.cc
+++ b/tests/ndarray.cc
@@ -10,6 +10,8 @@
  */
 #include "ndarray.h"
 
+#include <cstddef>
+
 #define BOOST_TEST_DYN_LINK
 #define BOOST_TEST_MODULE ndarray
 #include "boost/test/unit_test.hpp"
@@ -48,8 +50,8 @@ BOOST_AUTO_TEST_CASE(vectors) {
 
 BOOST_AUTO_TEST_CASE(cores) {
     typedef ndarray::detail::Core<3> Core;
-    ndarray::Vector<int,3> shape = ndarray::makeVector(4,3,2);
-    ndarray::Vector<int,3> strides = ndarray::makeVector(6,2,1);
+    ndarray::Vector<std::size_t,3> shape = ndarray::makeVector<std::size_t>(4,3,2);
+    ndarray::Vector<std::size_t,3> strides = ndarray::makeVector<std::size_t>(6,2,1);
     Core::Ptr core = Core::create(shape, strides);
     BOOST_CHECK_EQUAL(core->getRC(),1);
     Core::Ptr copy = core;
@@ -59,7 +61,7 @@ BOOST_AUTO_TEST_CASE(cores) {
 }
 
 BOOST_AUTO_TEST_CASE(allocation) {
-    ndarray::Vector<int,3> shape = ndarray::makeVector(5,6,7);
+    ndarray::Vector<std::size_t,3> shape = ndarray::makeVector<std::size_t>(5,6,7);
     ndarray::Array<float,3,3> a = ndarray::allocate(shape);
     BOOST_CHECK_EQUAL(a.getShape(), shape);
 
@@ -71,7 +73,7 @@ BOOST_AUTO_TEST_CASE(allocation) {
     BOOST_CHECK_EQUAL(b.getStride<0>(), 6*7);
     BOOST_CHECK_EQUAL(b.getStride<1>(), 7);
     BOOST_CHECK_EQUAL(b.getStride<2>(), 1);
-    BOOST_CHECK_EQUAL(b.getStrides(), ndarray::makeVector(6*7 ,7, 1));
+    BOOST_CHECK_EQUAL(b.getStrides(), ndarray::makeVector<std::size_t>(6*7 ,7, 1));
 
     ndarray::Array<float,3,-3> c = ndarray::allocate(5,6,7);
     BOOST_CHECK_EQUAL(c.getShape(), shape);
@@ -81,14 +83,14 @@ BOOST_AUTO_TEST_CASE(allocation) {
     BOOST_CHECK_EQUAL(c.getStride<0>(), 1);
     BOOST_CHECK_EQUAL(c.getStride<1>(), 5);
     BOOST_CHECK_EQUAL(c.getStride<2>(), 5*6);
-    BOOST_CHECK_EQUAL(c.getStrides(), ndarray::makeVector(1, 5, 5*6));
-    
+    BOOST_CHECK_EQUAL(c.getStrides(), ndarray::makeVector<std::size_t>(1, 5, 5*6));
+
 }
 
 BOOST_AUTO_TEST_CASE(external) {
     double data[3*4*2] = {0};
-    ndarray::Vector<int,3> shape = ndarray::makeVector(3,4,2);
-    ndarray::Vector<int,3> strides = ndarray::makeVector(8,2,1);
+    ndarray::Vector<std::size_t,3> shape = ndarray::makeVector<std::size_t>(3,4,2);
+    ndarray::Vector<std::size_t,3> strides = ndarray::makeVector<std::size_t>(8,2,1);
     ndarray::Array<double,3,3> a = ndarray::external(data,shape,strides);
     BOOST_CHECK_EQUAL(a.getData(), data);
     BOOST_CHECK_EQUAL(a.getShape(), shape);
@@ -97,16 +99,16 @@ BOOST_AUTO_TEST_CASE(external) {
 
 BOOST_AUTO_TEST_CASE(conversion) {
     double data[3*4*2] = {0};
-    ndarray::Vector<int,3> shape = ndarray::makeVector(3,4,2);
-    ndarray::Vector<int,3> strides = ndarray::makeVector(8,2,1);
+    ndarray::Vector<std::size_t,3> shape = ndarray::makeVector<std::size_t>(3,4,2);
+    ndarray::Vector<std::size_t,3> strides = ndarray::makeVector<std::size_t>(8,2,1);
     ndarray::Array<double,3,3> a = ndarray::external(data,shape,strides);
     ndarray::Array<double const,3> b = a;
 }
 
 BOOST_AUTO_TEST_CASE(shallow) {
     double data[3*4*2] = {0};
-    ndarray::Vector<int,3> shape = ndarray::makeVector(3,4,2);
-    ndarray::Vector<int,3> strides = ndarray::makeVector(8,2,1);
+    ndarray::Vector<std::size_t,3> shape = ndarray::makeVector<std::size_t>(3,4,2);
+    ndarray::Vector<std::size_t,3> strides = ndarray::makeVector<std::size_t>(8,2,1);
     ndarray::Array<double,3,3> a = ndarray::external(data,shape,strides);
     ndarray::Array<double,3,1> b = ndarray::external(data,shape,strides);
     BOOST_CHECK(a == b);
@@ -128,8 +130,8 @@ BOOST_AUTO_TEST_CASE(shallow) {
 
 BOOST_AUTO_TEST_CASE(casts) {
     double data[3*4*2] = {0};
-    ndarray::Vector<int,3> shape = ndarray::makeVector(3,4,2);
-    ndarray::Vector<int,3> strides = ndarray::makeVector(8,2,1);
+    ndarray::Vector<std::size_t,3> shape = ndarray::makeVector<std::size_t>(3,4,2);
+    ndarray::Vector<std::size_t,3> strides = ndarray::makeVector<std::size_t>(8,2,1);
     ndarray::Array<double const,3,1> a = ndarray::external(data,shape,strides);
     ndarray::Array<double const,3,2> b = ndarray::static_dimension_cast<2>(a);
     BOOST_CHECK(a == b);
@@ -144,8 +146,8 @@ BOOST_AUTO_TEST_CASE(casts) {
 
 BOOST_AUTO_TEST_CASE(complex) {
     std::complex<double> data[3*4*2] = { std::complex<double>(0.0,0.0) };
-    ndarray::Vector<int,3> shape = ndarray::makeVector(3,4,2);
-    ndarray::Vector<int,3> strides = ndarray::makeVector(8,2,1);
+    ndarray::Vector<std::size_t,3> shape = ndarray::makeVector<std::size_t>(3,4,2);
+    ndarray::Vector<std::size_t,3> strides = ndarray::makeVector<std::size_t>(8,2,1);
     ndarray::Array<std::complex<double>,3,3> a = ndarray::external(data,shape,strides);
     ndarray::Array<double const,3,0> re(getReal(a));
     ndarray::Array<double const,3,0> im(getImag(a));
@@ -155,40 +157,40 @@ BOOST_AUTO_TEST_CASE(complex) {
 }
 
 BOOST_AUTO_TEST_CASE(indexing) {
-    double data[3*4*2] = { 
+    double data[3*4*2] = {
          0, 1, 2, 3, 4, 5, 6, 7,
          8, 9,10,11,12,13,14,15,
         16,17,18,19,20,21,22,23,
     };
-    ndarray::Vector<int,3> a_shape = ndarray::makeVector(4,3,2);
-    ndarray::Vector<int,3> a_strides = ndarray::makeVector(6,2,1);
+    ndarray::Vector<std::size_t,3> a_shape = ndarray::makeVector<std::size_t>(4,3,2);
+    ndarray::Vector<std::size_t,3> a_strides = ndarray::makeVector<std::size_t>(6,2,1);
     ndarray::Array<double,3,3> a = ndarray::external(data, a_shape, a_strides);
     BOOST_CHECK(a.front().shallow() == a[0].shallow());
     BOOST_CHECK(a.back().shallow() == a[a_shape[0]-1].shallow());
-    int n = 0;
-    for (int i=0; i<a_shape[0]; ++i) {
-        for (int j=0; j<a_shape[1]; ++j) {
-            for (int k=0; k<a_shape[2]; ++k) {
+    std::size_t n = 0;
+    for (std::size_t i=0; i<a_shape[0]; ++i) {
+        for (std::size_t j=0; j<a_shape[1]; ++j) {
+            for (std::size_t k=0; k<a_shape[2]; ++k) {
                 BOOST_CHECK_EQUAL(a[i][j][k], n);
                 BOOST_CHECK_EQUAL(a(i,j,k), n);
                 ++n;
             }
         }
     }
-    ndarray::Vector<int,2> b_shape = ndarray::makeVector(8,3);
-    ndarray::Vector<int,2> b_strides = ndarray::makeVector(1,8);
+    ndarray::Vector<std::size_t,2> b_shape = ndarray::makeVector<std::size_t>(8,3);
+    ndarray::Vector<std::size_t,2> b_strides = ndarray::makeVector<std::size_t>(1,8);
     ndarray::Array<double,2> b = ndarray::external(data, b_shape, b_strides);
-    for (int i=0; i<b_shape[0]; ++i) {
-        for (int j=0; j<b_shape[1]; ++j) {
+    for (std::size_t i=0; i<b_shape[0]; ++i) {
+        for (std::size_t j=0; j<b_shape[1]; ++j) {
             BOOST_CHECK_EQUAL(b[i][j], i+8*j);
             BOOST_CHECK_EQUAL(b(i,j), i+8*j);
         }
     }
-    ndarray::Vector<int,2> c_shape = ndarray::makeVector(4,3);
-    ndarray::Vector<int,2> c_strides = ndarray::makeVector(1,8);
+    ndarray::Vector<std::size_t,2> c_shape = ndarray::makeVector<std::size_t>(4,3);
+    ndarray::Vector<std::size_t,2> c_strides = ndarray::makeVector<std::size_t>(1,8);
     ndarray::Array<double,2> c = ndarray::external(data, c_shape, c_strides);
-    for (int i=0; i<c_shape[0]; ++i) {
-        for (int j=0; j<c_shape[1]; ++j) {
+    for (std::size_t i=0; i<c_shape[0]; ++i) {
+        for (std::size_t j=0; j<c_shape[1]; ++j) {
             BOOST_CHECK_EQUAL(c[i][j], i+8*j);
             BOOST_CHECK_EQUAL(c(i,j), i+8*j);
         }
@@ -196,13 +198,13 @@ BOOST_AUTO_TEST_CASE(indexing) {
 }
 
 BOOST_AUTO_TEST_CASE(iterators) {
-    double data[3*4*2] = { 
+    double data[3*4*2] = {
          0, 1, 2, 3, 4, 5, 6, 7,
          8, 9,10,11,12,13,14,15,
         16,17,18,19,20,21,22,23,
     };
-    ndarray::Vector<int,3> a_shape = ndarray::makeVector(4,3,2);
-    ndarray::Vector<int,3> a_strides = ndarray::makeVector(6,2,1);
+    ndarray::Vector<std::size_t,3> a_shape = ndarray::makeVector<std::size_t>(4,3,2);
+    ndarray::Vector<std::size_t,3> a_strides = ndarray::makeVector<std::size_t>(6,2,1);
     ndarray::Array<double,3,3> a = ndarray::external(data, a_shape, a_strides);
     ndarray::Array<double,3,3>::Iterator ai_iter = a.begin();
     ndarray::Array<double,3,3>::Iterator const ai_end = a.end();
@@ -217,8 +219,8 @@ BOOST_AUTO_TEST_CASE(iterators) {
             }
         }
     }
-    ndarray::Vector<int,2> b_shape = ndarray::makeVector(4,3);
-    ndarray::Vector<int,2> b_strides = ndarray::makeVector(1,8);
+    ndarray::Vector<std::size_t,2> b_shape = ndarray::makeVector<std::size_t>(4,3);
+    ndarray::Vector<std::size_t,2> b_strides = ndarray::makeVector<std::size_t>(1,8);
     ndarray::Array<double,2> b = ndarray::external(data, b_shape, b_strides);
     ndarray::Array<double,2>::Iterator bi_iter = b.begin();
     ndarray::Array<double,2>::Iterator const bi_end = b.end();
@@ -233,38 +235,38 @@ BOOST_AUTO_TEST_CASE(iterators) {
 }
 
 BOOST_AUTO_TEST_CASE(views) {
-    ndarray::Vector<int,3> shape = ndarray::makeVector(4,3,2);
+    ndarray::Vector<std::size_t,3> shape = ndarray::makeVector<std::size_t>(4,3,2);
     ndarray::Array<double,3,3> a = ndarray::allocate(shape);
     BOOST_CHECK(a == a[ndarray::view()()].shallow());
     BOOST_CHECK(a == a[ndarray::view()].shallow());
-    BOOST_CHECK(a[1].shallow() == a[ndarray::view(1)].shallow());
-    BOOST_CHECK(a[1][2].shallow() == a[ndarray::view(1)(2)].shallow());
+    BOOST_CHECK(a[1].shallow() == a[ndarray::view((std::size_t)1)].shallow());
+    BOOST_CHECK(a[1][2].shallow() == a[ndarray::view((std::size_t)1)((std::size_t)2)].shallow());
     BOOST_CHECK(a != a[ndarray::view(0,3)].shallow());
     ndarray::Array<double const,2> b = a[ndarray::view()(1,3)(0)];
-    BOOST_CHECK(b.getShape() == ndarray::makeVector(4,2));
-    BOOST_CHECK(b.getStrides() == ndarray::makeVector(6,2));
+    BOOST_CHECK(b.getShape() == ndarray::makeVector<std::size_t>(4,2));
+    BOOST_CHECK(b.getStrides() == ndarray::makeVector<std::size_t>(6,2));
     BOOST_CHECK(b.getData() == a.getData() + 2);
     ndarray::Array<double const,2> c = b[ndarray::view(0,4,2)()];
-    BOOST_CHECK(c.getShape() == ndarray::makeVector(2,2));
-    BOOST_CHECK(c.getStrides() == ndarray::makeVector(12,2));
+    BOOST_CHECK(c.getShape() == ndarray::makeVector<std::size_t>(2,2));
+    BOOST_CHECK(c.getStrides() == ndarray::makeVector<std::size_t>(12,2));
     BOOST_CHECK(c.getData() == b.getData());
 }
 
 #ifndef GCC_45
 
 BOOST_AUTO_TEST_CASE(predicates) {
-    double data1[3*4*2] = { 
+    double data1[3*4*2] = {
          0, 1, 2, 3, 4, 5, 6, 7,
          8, 9,10,11,12,13,14,15,
         16,17,18,19,20,21,22,23,
     };
-    double data2[3*4*2] = { 
+    double data2[3*4*2] = {
          0, 1, 2, 3, 4, 5, 6, 7,
          8, 9,10,11,12,13,14,15,
         16,17,18,19,20,21,22,23,
     };
-    ndarray::Vector<int,3> shape = ndarray::makeVector(4,3,2);
-    ndarray::Vector<int,3> strides = ndarray::makeVector(6,2,1);
+    ndarray::Vector<std::size_t,3> shape = ndarray::makeVector<std::size_t>(4,3,2);
+    ndarray::Vector<std::size_t,3> strides = ndarray::makeVector<std::size_t>(6,2,1);
     ndarray::Array<double const,3,3> a = ndarray::external(data1, shape, strides);
     ndarray::Array<bool,3,2> b = ndarray::allocate(shape);
     ndarray::Array<bool,3> c = ndarray::allocate(shape);
@@ -299,15 +301,15 @@ BOOST_AUTO_TEST_CASE(predicates) {
 }
 
 BOOST_AUTO_TEST_CASE(allclose) {
-   float data[3*4*2] = { 
+   float data[3*4*2] = {
          0, 1, 2, 3, 4, 5, 6, 7,
          8, 9,10,11,12,13,14,15,
         16,17,18,19,20,21,22,23,
     };
-    ndarray::Vector<int,3> shape = ndarray::makeVector(4,3,2);
-    ndarray::Vector<int,3> strides = ndarray::makeVector(6,2,1);
+    ndarray::Vector<std::size_t,3> shape = ndarray::makeVector<std::size_t>(4,3,2);
+    ndarray::Vector<std::size_t,3> strides = ndarray::makeVector<std::size_t>(6,2,1);
     ndarray::Array<float,3,2> a = ndarray::external(data,shape,strides);
-    ndarray::Array<double,4,4> b = ndarray::allocate(ndarray::concatenate(shape, 3));
+    ndarray::Array<double,4,4> b = ndarray::allocate(ndarray::concatenate(shape, (std::size_t)3));
     ndarray::Array<double,3,3> c = ndarray::allocate(shape);
     c.deep() = a + 1.2;
     b.deep() = a + 1.2;
@@ -318,13 +320,13 @@ BOOST_AUTO_TEST_CASE(allclose) {
 }
 
 BOOST_AUTO_TEST_CASE(binary_ops) {
-    float data[3*4*2] = { 
+    float data[3*4*2] = {
          0, 1, 2, 3, 4, 5, 6, 7,
          8, 9,10,11,12,13,14,15,
         16,17,18,19,20,21,22,23,
     };
-    ndarray::Vector<int,3> shape = ndarray::makeVector(4,3,2);
-    ndarray::Vector<int,3> strides = ndarray::makeVector(6,2,1);
+    ndarray::Vector<std::size_t,3> shape = ndarray::makeVector<std::size_t>(4,3,2);
+    ndarray::Vector<std::size_t,3> strides = ndarray::makeVector<std::size_t>(6,2,1);
     ndarray::Array<float,3,2> a = ndarray::external(data,shape,strides);
     ndarray::Array<double,3,1> b = ndarray::allocate(shape);
     ndarray::Array<double,3,3> c = ndarray::allocate(shape);
@@ -344,21 +346,21 @@ BOOST_AUTO_TEST_CASE(binary_ops) {
 }
 
 BOOST_AUTO_TEST_CASE(broadcasting) {
-    double data3[3*4*2] = { 
+    double data3[3*4*2] = {
          0, 1, 2, 3, 4, 5, 6, 7,
          8, 9,10,11,12,13,14,15,
         16,17,18,19,20,21,22,23,
     };
-    double data2[3*4] = { 
+    double data2[3*4] = {
         0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11,
     };
-    double data32[3*4*2] = { 
+    double data32[3*4*2] = {
         0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11,
     };
-    ndarray::Vector<int,3> shape3 = ndarray::makeVector(3,4,2);
-    ndarray::Vector<int,3> strides3 = ndarray::makeVector(8,2,1);
-    ndarray::Vector<int,2> shape2 = ndarray::makeVector(3,4);
-    ndarray::Vector<int,2> strides2 = ndarray::makeVector(4,1);
+    ndarray::Vector<std::size_t,3> shape3 = ndarray::makeVector<std::size_t>(3,4,2);
+    ndarray::Vector<std::size_t,3> strides3 = ndarray::makeVector<std::size_t>(8,2,1);
+    ndarray::Vector<std::size_t,2> shape2 = ndarray::makeVector<std::size_t>(3,4);
+    ndarray::Vector<std::size_t,2> strides2 = ndarray::makeVector<std::size_t>(4,1);
     ndarray::Array<double const,3,3> a3 = ndarray::external(data3,shape3,strides3);
     ndarray::Array<double const,3,3> a32 = ndarray::external(data32,shape3,strides3);
     ndarray::Array<double const,2,2> a2 = ndarray::external(data2,shape2,strides2);
@@ -380,13 +382,13 @@ BOOST_AUTO_TEST_CASE(broadcasting) {
 #endif
 
 BOOST_AUTO_TEST_CASE(assignment) {
-    double data[3*4*2] = { 
+    double data[3*4*2] = {
          0, 1, 2, 3, 4, 5, 6, 7,
          8, 9,10,11,12,13,14,15,
         16,17,18,19,20,21,22,23,
     };
-    ndarray::Vector<int,3> shape = ndarray::makeVector(3,4,2);
-    ndarray::Vector<int,3> strides = ndarray::makeVector(8,2,1);
+    ndarray::Vector<std::size_t,3> shape = ndarray::makeVector<std::size_t>(3,4,2);
+    ndarray::Vector<std::size_t,3> strides = ndarray::makeVector<std::size_t>(8,2,1);
     ndarray::Array<double,3,3> a = ndarray::external(data,shape,strides);
     ndarray::Array<double,3,3> b = ndarray::allocate(shape);
     b.deep() = a;
@@ -438,11 +440,11 @@ BOOST_AUTO_TEST_CASE(transpose) {
          8, 9,10,11,12,13,14,15,
         16,17,18,19,20,21,22,23,
     };
-    ndarray::Vector<int,3> shape = ndarray::makeVector(3,4,2);
-    ndarray::Vector<int,3> strides = ndarray::makeVector(8,2,1);
+    ndarray::Vector<std::size_t,3> shape = ndarray::makeVector<std::size_t>(3,4,2);
+    ndarray::Vector<std::size_t,3> strides = ndarray::makeVector<std::size_t>(8,2,1);
     ndarray::Array<double,3,3> a = ndarray::external(data,shape,strides);
     ndarray::Array<double const,3,-3> b = a.transpose();
-    ndarray::Array<double const,3> c = a.transpose(ndarray::makeVector(1,0,2));
+    ndarray::Array<double const,3> c = a.transpose(ndarray::makeVector<std::size_t>(1,0,2));
     for (int i=0; i<shape[0]; ++i) {
         for (int j=0; j<shape[1]; ++j) {
             for (int k=0; k<shape[2]; ++k) {
@@ -451,16 +453,16 @@ BOOST_AUTO_TEST_CASE(transpose) {
             }
         }
     }
-    BOOST_CHECK(a[ndarray::view()(1)(1)].shallow() == b[ndarray::view(1)(1)()].shallow());
-    BOOST_CHECK(a[ndarray::view(0)()(1)].shallow() == b[ndarray::view(1)()(0)].shallow());
-    BOOST_CHECK(a[ndarray::view(0)(0)()].shallow() == b[ndarray::view()(0)(0)].shallow());
-    BOOST_CHECK(a[ndarray::view()(1)(1)].shallow() == c[ndarray::view(1)()(1)].shallow());
-    BOOST_CHECK(a[ndarray::view(0)()(1)].shallow() == c[ndarray::view()(0)(1)].shallow());
-    BOOST_CHECK(a[ndarray::view(0)(0)()].shallow() == c[ndarray::view(0)(0)()].shallow());
+    BOOST_CHECK(a[ndarray::view()(1)(1)].shallow() == b[ndarray::view((std::size_t)1)((std::size_t)1)()].shallow());
+    BOOST_CHECK(a[ndarray::view((std::size_t)0)()((std::size_t)1)].shallow() == b[ndarray::view((std::size_t)1)()((std::size_t)0)].shallow());
+    BOOST_CHECK(a[ndarray::view((std::size_t)0)((std::size_t)0)()].shallow() == b[ndarray::view()((std::size_t)0)((std::size_t)0)].shallow());
+    BOOST_CHECK(a[ndarray::view()((std::size_t)1)((std::size_t)1)].shallow() == c[ndarray::view((std::size_t)1)()((std::size_t)1)].shallow());
+    BOOST_CHECK(a[ndarray::view((std::size_t)0)()((std::size_t)1)].shallow() == c[ndarray::view()((std::size_t)0)((std::size_t)1)].shallow());
+    BOOST_CHECK(a[ndarray::view((std::size_t)0)((std::size_t)0)()].shallow() == c[ndarray::view((std::size_t)0)((std::size_t)0)()].shallow());
 
     {
-        ndarray::Array<double const,2,2> a1 = a[ndarray::view(0)()()];
-        ndarray::Array<double const,2,-2> b1 = b[ndarray::view()()(0)];
+        ndarray::Array<double const,2,2> a1 = a[ndarray::view((std::size_t)0)()()];
+        ndarray::Array<double const,2,-2> b1 = b[ndarray::view()()((std::size_t)0)];
         BOOST_CHECK(b1.transpose().shallow() == a1.shallow());
         BOOST_CHECK(a1.transpose().shallow() == b1.shallow());
     }
@@ -496,22 +498,26 @@ BOOST_AUTO_TEST_CASE(transpose) {
 }
 
 BOOST_AUTO_TEST_CASE(flatten) {
-    double data[3*4*2] = { 
+    double data[3*4*2] = {
          0, 1, 2, 3, 4, 5, 6, 7,
          8, 9,10,11,12,13,14,15,
         16,17,18,19,20,21,22,23,
     };
-    ndarray::Vector<int,3> a_shape = ndarray::makeVector(4,3,2);
-    ndarray::Vector<int,3> a_strides = ndarray::makeVector(6,2,1);
+    ndarray::Vector<std::size_t,3> a_shape = ndarray::makeVector<std::size_t>(4,3,2);
+    ndarray::Vector<std::size_t,3> a_strides = ndarray::makeVector<std::size_t>(6,2,1);
     ndarray::Array<double,3,3> a = ndarray::external(data,a_shape,a_strides);
     ndarray::Array<double,2,2> b = ndarray::flatten<2>(a);
     ndarray::Array<double,2,2> b_check = ndarray::external(
-        data, ndarray::makeVector(4,6), ndarray::makeVector(6,1)
+        data,
+        ndarray::makeVector<std::size_t>(4,6),
+        ndarray::makeVector<std::size_t>(6,1)
     );
     BOOST_CHECK(b.shallow() == b_check.shallow());
     ndarray::Array<double,1,1> c = ndarray::flatten<1>(a);
     ndarray::Array<double,1,1> c_check = ndarray::external(
-        data, ndarray::makeVector(24), ndarray::makeVector(1)
+        data,
+        ndarray::makeVector<std::size_t>(24),
+        ndarray::makeVector<std::size_t>(1)
     );
 }
 
@@ -522,7 +528,7 @@ BOOST_AUTO_TEST_CASE(unique) {
     BOOST_CHECK(!a.isUnique());
     BOOST_CHECK(!b.isUnique());
     a = ndarray::Array<double,2,2>();
-    BOOST_CHECK(b.isUnique());    
+    BOOST_CHECK(b.isUnique());
     ndarray::Array<double const,2,1> c = b[ndarray::view(1,4)(1,3)];
     BOOST_CHECK(!c.isUnique());
     BOOST_CHECK(!b.isUnique());
@@ -562,7 +568,7 @@ BOOST_AUTO_TEST_CASE(zeroSize) {
 
 BOOST_AUTO_TEST_CASE(manager) {
     ndarray::Array<double,1,1> a = ndarray::allocate(5);
-    ndarray::Array<double,1,1> b 
+    ndarray::Array<double,1,1> b
         = ndarray::external(a.getData(), a.getShape(), a.getStrides(), a.getManager());
     BOOST_CHECK_EQUAL(a.getManager(), b.getManager()); // no extra indirection in makeManager
 }

--- a/tests/python_test.py
+++ b/tests/python_test.py
@@ -20,10 +20,18 @@ class TestNDArray(unittest.TestCase):
         self.assert_(a1.flags["WRITEABLE"])
         self.assert_(a2.flags["WRITEABLE"])
 
+        ua1 = numpy.zeros((5,3,4),dtype=numpy.uint32)
+        self.assert_(ua1.flags["WRITEABLE"])
+
         b1 = python_test_mod.passIntArray33(a1)
         self.assert_(b1.flags["WRITEABLE"])
         self.assertEqual(a1.shape,b1.shape)
         self.assertEqual(a1.strides,b1.strides)
+
+        ub1 = python_test_mod.passuIntArray33(ua1)
+        self.assert_(ub1.flags["WRITEABLE"])
+        self.assertEqual(a1.shape,ub1.shape)
+        self.assertEqual(a1.strides,ub1.strides)
 
         c1 = python_test_mod.passIntArray30(a1)
         self.assert_(c1.flags["WRITEABLE"])
@@ -46,7 +54,7 @@ class TestNDArray(unittest.TestCase):
         self.assertRaises(TypeError, python_test_mod.passIntArray30, ((1,1,1),(2,2,2),(3,3,3)))
 
         # test to be sure an array of the wrong type does not work
-        self.assertRaises(ValueError, python_test_mod.passIntArray30, 
+        self.assertRaises(ValueError, python_test_mod.passIntArray30,
                           numpy.zeros((4,3,4),dtype=numpy.float))
 
     def testVectorConversion(self):
@@ -84,7 +92,7 @@ class TestNDArray(unittest.TestCase):
         self.assertEqual(a2.strides,c2.strides)
 
         # test to be sure a tuple of tuples does not work
-        self.assertRaises(TypeError, python_test_mod.passFloatArray30, 
+        self.assertRaises(TypeError, python_test_mod.passFloatArray30,
                           ((1.0,1.0,1.0),(2.0,2.0,2.0),(3.0,3.0,3.0)))
 
         # test to be sure an array of the wrong type does not work
@@ -101,7 +109,7 @@ class TestNDArray(unittest.TestCase):
 
     def testFloatArrayCreation(self):
         a = python_test_mod.makeFloatArray3((3,4,5))
-    
+
     def testIntArrayCreation(self):
         a = python_test_mod.makeIntArray3((3,4,5))
 

--- a/tests/python_test_mod.cc
+++ b/tests/python_test_mod.cc
@@ -8,10 +8,13 @@
  * of the source distribution, or alternately available at:
  * https://github.com/ndarray/ndarray
  */
+#include <cstddef>
 #include "Python.h"
 #include "numpy/arrayobject.h"
 #include "ndarray/swig.h"
+#ifndef _MSC_VER
 #pragma GCC diagnostic ignored "-Wuninitialized"
+#endif
 
 template <typename T, int N>
 static PyObject * passVector(PyObject * self, PyObject * args) {
@@ -31,8 +34,8 @@ static PyObject * passArray(PyObject * self, PyObject * args) {
 
 template <typename T, int N>
 static PyObject * makeArray(PyObject * self, PyObject * args) {
-    ndarray::Vector<int,N> shape;
-    if (!PyArg_ParseTuple(args,"O&",ndarray::PyConverter< ndarray::Vector<int,N> >::fromPython,&shape))
+    ndarray::Vector<std::size_t,N> shape;
+    if (!PyArg_ParseTuple(args,"O&",ndarray::PyConverter< ndarray::Vector<std::size_t,N> >::fromPython,&shape))
         return NULL;
     ndarray::Array<T,N,N> array = ndarray::allocate(shape);
     array.deep() = static_cast<T>(0);
@@ -47,6 +50,7 @@ static PyMethodDef methods[] = {
     {"makeFloatArray3",&makeArray<double,3>,METH_VARARGS,NULL},
     {"passIntVector3",&passVector<int,3>,METH_VARARGS,NULL},
     {"passIntArray33",&passArray<int,3,3>,METH_VARARGS,NULL},
+    {"passuIntArray33",&passArray<unsigned int,3,3>,METH_VARARGS,NULL},
     {"passConstIntArray33",&passArray<int const,3,3>,METH_VARARGS,NULL},
     {"passIntArray30",&passArray<int,3,0>,METH_VARARGS,NULL},
     {"makeIntArray3",&makeArray<int,3>,METH_VARARGS,NULL},

--- a/tests/swig_test_mod.i
+++ b/tests/swig_test_mod.i
@@ -11,10 +11,13 @@
 %module swig_test_mod
 %{
 #define PY_ARRAY_UNIQUE_SYMBOL LSST_SWIG_TEST_NUMPY_ARRAY_API
+#include <cstddef>
 #include "numpy/arrayobject.h"
 #include "ndarray/swig.h"
 #include "ndarray/swig/eigen.h"
+#ifdef __GNUC__
 #pragma GCC diagnostic ignored "-Wuninitialized"
+#endif
 %}
 %init %{
     import_array();
@@ -51,7 +54,7 @@ Eigen::Matrix2d returnMatrix2d() {
 }
 
 ndarray::Array<double,1,1> returnArray1() {
-    ndarray::Array<double,1,1> r(ndarray::allocate(ndarray::makeVector(6)));
+    ndarray::Array<double,1,1> r(ndarray::allocate(ndarray::makeVector<std::size_t>(6)));
     for (int n = 0; n < r.getSize<0>(); ++n) {
         r[n] = n;
     }
@@ -63,9 +66,9 @@ ndarray::Array<double const,1,1> returnConstArray1() {
 }
 
 ndarray::Array<double,3> returnArray3() {
-    ndarray::Array<double,3,3> r(ndarray::allocate(ndarray::makeVector(4,3,2)));
+    ndarray::Array<double,3,3> r(ndarray::allocate(ndarray::makeVector<std::size_t>(4,3,2)));
     ndarray::Array<double,1,1> f = ndarray::flatten<1>(r);
-    for (int n = 0; n < f.getSize<0>(); ++n) {
+    for (std::size_t n = 0; n < f.getSize<0>(); ++n) {
         f[n] = n;
     }
     return r;
@@ -101,8 +104,8 @@ bool acceptArray3(ndarray::Array<double,3> const & a1) {
 #ifndef GCC_45
     return ndarray::all(ndarray::equal(a1, a2));
 #else
-    for (int i = 0; i < a1.getSize<0>(); ++i) {
-      for (int j = 0; j < a1.getSize<1>(); ++j) {
+    for (std::size_t i = 0; i < a1.getSize<0>(); ++i) {
+      for (std::size_t j = 0; j < a1.getSize<1>(); ++j) {
 	if (!std::equal(a1[i][j].begin(), a1[i][j].end(), a2[i][j].begin())) return false;
       }
     }


### PR DESCRIPTION
Dear ndarray team,

we are using Boost.NumPy and the ndarray project in a big data context at our lab. So I made the effort and made both projects x64 Python compatible, as well as the ndarrays 64bit indexed (similar to eigen3). I was mainly working on Windows and had to test the projects, so at the same time I extended the SCons build system to work with Windows.

After all changes, both projects build without any internal warnings (the numpy interface deprecation warning left aside) and are working flawlessly on Windows and Linux. All tests are passing.

The changes here are extensive, but focus on x64 indexing for the arrays. The number of dimensions is still left to be an integer, as well as the int fftw-interface is still used (but can now also easily be replaced by the x64 interface).

I am ready to answer questions and hope it is a useful contribution to the project!

Best,
Christoph