### PR TITLE
Changes to source code from LSST

### DIFF
--- a/include/ndarray.h
+++ b/include/ndarray.h
@@ -29,7 +29,7 @@
 namespace ndarray {
 
 /** 
- * @mainpage Multidimensional Arrays in C++
+ * @mainpage ndarray; Multidimensional Arrays in C++
  *
  * %ndarray is a template library that provides multidimensional array objects in C++, with
  * an interface and features designed to mimic the Python 'numpy' package as much as possible.

--- a/include/ndarray/Array.h
+++ b/include/ndarray/Array.h
@@ -174,7 +174,7 @@ private:
     template <typename T_, int N_, int C_> friend class ArrayRef;
     template <typename T_, int N_, int C_> friend struct ArrayTraits;
     template <typename Derived> friend class ArrayBase;
-    template <typename Array_> friend struct detail::ArrayAccess;
+    template <typename Array_> friend class detail::ArrayAccess;
 
     /// @internal @brief Construct an Array from a pointer and Core.
     Array(T * data, CorePtr const & core) : Super(data, core) {}

--- a/include/ndarray/ArrayBase.h
+++ b/include/ndarray/ArrayBase.h
@@ -236,7 +236,7 @@ protected:
     template <typename T_, int N_, int C_> friend struct ArrayTraits;
     template <typename T_, int N_, int C_> friend class detail::NestedIterator;
     template <typename Derived_> friend class ArrayBase;
-    template <typename Array_> friend struct detail::ArrayAccess;
+    template <typename Array_> friend class detail::ArrayAccess;
 
     Element * _data;
     CorePtr _core;

--- a/include/ndarray/ArrayRef.h.m4
+++ b/include/ndarray/ArrayRef.h.m4
@@ -33,7 +33,7 @@ define(`GENERAL_ASSIGN',
         indir(`$2',$1)
         return *this;
     }')dnl
-define(`BASIC_ASSIGN_SCALAR',`std::fill(this->begin(),this->end(),scalar);')dnl
+define(`BASIC_ASSIGN_SCALAR',`Super::Traits::fill(this->begin(),this->end(),scalar);')dnl
 define(`BASIC_ASSIGN_EXPR',`std::copy(expr.begin(),expr.end(),this->begin());')dnl
 define(`AUGMENTED_ASSIGN_SCALAR',
 `Iterator const i_end = this->end();

--- a/include/ndarray/ArrayTraits.h
+++ b/include/ndarray/ArrayTraits.h
@@ -57,6 +57,16 @@ struct ArrayTraits {
     static Iterator makeIterator(Element * data, CorePtr const & core, Offset stride) {
         return Iterator(Reference(data, core), stride);
     }
+    static void fill(Iterator iter, Iterator const & end, Element value) {
+        // We can't use std::fill here because NestedIterator is not formally an STL ForwardIterator;
+        // it has random access traversal, but it does not dereference to an addressable type (see
+        // http://www.boost.org/doc/libs/1_55_0/libs/iterator/doc/new-iter-concepts.html#motivation)
+        // Most C++ standard libraries have a fill implementation that will accept NestedIterator
+        // anyway, but Clang's libc++ is more strictly compliant and does not.
+        for (; iter != end; ++iter) {
+            *iter = value;
+        }
+    }
 };
 
 template <typename T>
@@ -75,6 +85,9 @@ struct ArrayTraits<T,1,0> {
     }
     static Iterator makeIterator(Element * data, CorePtr const & core, Offset stride) {
         return Iterator(data, stride);
+    }
+    static void fill(Iterator iter, Iterator const & end, Element value) {
+        std::fill(iter, end, value);
     }
 };
 
@@ -95,6 +108,9 @@ struct ArrayTraits<T,1,1> {
     static Iterator makeIterator(Element * data, CorePtr const & core, Offset stride) {
         return data;
     }
+    static void fill(Iterator iter, Iterator const & end, Element value) {
+        std::fill(iter, end, value);
+    }
 };
 
 template <typename T>
@@ -113,6 +129,9 @@ struct ArrayTraits<T,1,-1> {
     }
     static Iterator makeIterator(Element * data, CorePtr const & core, Offset stride) {
         return data;
+    }
+    static void fill(Iterator iter, Iterator const & end, Element value) {
+        std::fill(iter, end, value);
     }
 };
 

--- a/include/ndarray/Vector.h.m4
+++ b/include/ndarray/Vector.h.m4
@@ -75,6 +75,7 @@ define(`VECTOR_TYPEDEFS',
 
 /// @file ndarray/Vector.h Definition for Vector.
 
+#include <boost/type_traits/is_arithmetic.hpp>
 #include <boost/iterator/reverse_iterator.hpp>
 #include <boost/utility/enable_if.hpp>
 #include <boost/mpl/int.hpp>
@@ -106,6 +107,20 @@ define(`VECTOR_TYPEDEFS',
 /// \endcond
 
 namespace ndarray {
+
+namespace detail {
+
+template <typename T, bool isArithmetic=boost::is_arithmetic<T>::value>
+struct DefaultValue {
+    static T get() { return T(); }
+};
+
+template <typename T>
+struct DefaultValue<T,true> {
+    static T get() { return T(0); }
+};
+
+} // namespace detail
 
 /// \addtogroup ndarrayVectorGroup
 /// @{
@@ -204,7 +219,7 @@ struct Vector {
 	#ifndef _MSC_VER
 	template 
 	#endif
-	operator=(0); }
+	operator=(detail::DefaultValue<T>::get()); }
 
     /// @brief Construct with copies of a scalar.
     explicit Vector(T scalar) {

--- a/include/ndarray/casts.h
+++ b/include/ndarray/casts.h
@@ -22,6 +22,7 @@
 #include <boost/type_traits/add_const.hpp>
 #include <boost/type_traits/remove_const.hpp>
 #include <boost/mpl/comparison.hpp>
+#include <boost/utility/enable_if.hpp>
 #include <boost/static_assert.hpp>
 
 namespace ndarray {

--- a/include/ndarray/casts.h
+++ b/include/ndarray/casts.h
@@ -147,6 +147,18 @@ flatten(Array<T,N,C> const & input) {
     return Access::construct(input.getData(), Core::create(newShape, newStrides, input.getManager()));
 }
 
+/**
+ *  @brief Create a view into an array with trailing contiguous dimensions merged.
+ *
+ *  The first template parameter sets the dimension of the output array and must
+ *  be specified directly.  Only row-major contiguous dimensions can be flattened.
+ */
+template <int Nf, typename T, int N, int C>
+inline typename boost::enable_if_c< ((C+Nf-N)>=1), ArrayRef<T,Nf,(C+Nf-N)> >::type
+flatten(ArrayRef<T,N,C> const & input) {
+    return flatten<Nf>(input.shallow());
+}
+
 /// @}
 
 } // namespace ndarray

--- a/include/ndarray/detail/ArrayAccess.h
+++ b/include/ndarray/detail/ArrayAccess.h
@@ -23,7 +23,8 @@ namespace ndarray {
 namespace detail {
 
 template <typename Array_>
-struct ArrayAccess {
+class ArrayAccess {
+public:
     typedef typename ExpressionTraits< Array_ >::Element Element;
     typedef typename ExpressionTraits< Array_ >::Core Core;
     typedef typename ExpressionTraits< Array_ >::CorePtr CorePtr;

--- a/include/ndarray/eigen.h
+++ b/include/ndarray/eigen.h
@@ -261,7 +261,20 @@ public:
         return *this;
     }
 
-    using Base::operator=;
+    template <typename Other>
+    EigenView & operator=(Eigen::DenseBase<Other> const & other) {
+        return Base::operator=(other);
+    }
+
+    template <typename Other>
+    EigenView & operator=(Eigen::EigenBase<Other> const & other) {
+        return Base::operator=(other);
+    }
+
+    template <typename Other>
+    EigenView & operator=(Eigen::ReturnByValue<Other> const & other) {
+        return Base::operator=(other);
+    }
 
     inline Index innerStride() const { return ST::getInnerStride(*Access::getCore(_array)); }
     inline Index outerStride() const { return ST::getOuterStride(*Access::getCore(_array)); }

--- a/include/ndarray/formatting.h
+++ b/include/ndarray/formatting.h
@@ -23,7 +23,7 @@
 
 namespace ndarray {
 namespace detail {
-template <typename Derived, int N = Derived::ND::value> struct Formatter;
+template <typename Derived, int N = Derived::ND::value> class Formatter;
 } // namespace detail
 
 /**
@@ -81,7 +81,8 @@ namespace detail {
  *  @brief Recursive metafunction used in stream output.
  */
 template <typename Derived, int N>
-struct Formatter {
+class Formatter {
+public:
     static void apply(
         FormatOptions const & options,
         std::ostream & os, 
@@ -108,7 +109,8 @@ struct Formatter {
  *  @brief Recursive metafunction used in stream output (1d specialization).
  */
 template <typename Derived>
-struct Formatter<Derived,1> {
+class Formatter<Derived,1> {
+public:
     static void apply(
         FormatOptions const & options,
         std::ostream & os, 

--- a/include/ndarray/initialization.h
+++ b/include/ndarray/initialization.h
@@ -69,7 +69,6 @@ public:
     Target apply() const {
         typedef detail::ArrayAccess< Target > Access;
         typedef typename Access::Core Core;
-        typedef typename Access::Element Element;
         Manager::Ptr manager;
         if (!boost::is_same<Owner,NullOwner>::value) {
             manager = makeManager(_owner);

--- a/include/ndarray/operators.h.m4
+++ b/include/ndarray/operators.h.m4
@@ -88,6 +88,7 @@ define(`UNARY_OP',
 #include "ndarray/Array.h"
 #include <boost/call_traits.hpp>
 #include <boost/functional.hpp>
+#include <boost/utility/enable_if.hpp>
 
 #include "ndarray/detail/UnaryOp.h"
 #include "ndarray/detail/BinaryOp.h"

--- a/include/ndarray/vectorize.h
+++ b/include/ndarray/vectorize.h
@@ -19,6 +19,7 @@
 #include "ndarray/detail/UnaryOp.h"
 
 #include <boost/mpl/and.hpp>
+#include <boost/utility/enable_if.hpp>
 
 namespace ndarray {
 namespace result_of {

--- a/include/ndarray_fwd.h
+++ b/include/ndarray_fwd.h
@@ -30,6 +30,7 @@
 #include <boost/type_traits/is_const.hpp>
 #include <boost/type_traits/add_const.hpp>
 #include <boost/type_traits/remove_const.hpp>
+#include <boost/mpl/bool.hpp>
 #include <cassert>
 
 #ifdef __GNUC__

--- a/tests/ndarray.cc
+++ b/tests/ndarray.cc
@@ -44,6 +44,12 @@ BOOST_AUTO_TEST_CASE(vectors) {
     BOOST_CHECK_EQUAL(a, f);
 
     e = a.last<0>();
+
+    // make sure we can default-construct whether or not T is a number
+    ndarray::Vector<boost::shared_ptr<int>,2> g;
+    BOOST_CHECK_EQUAL(g, ndarray::makeVector(boost::shared_ptr<int>(), boost::shared_ptr<int>()));
+    ndarray::Vector<int,3> h;
+    BOOST_CHECK_EQUAL(h, ndarray::makeVector(0, 0, 0));
 }
 
 BOOST_AUTO_TEST_CASE(cores) {


### PR DESCRIPTION
These are cherry-picks of all the code changes applied by LSST to their version of ndarray. Submitted at the request of @jdswinbank. I haven't gone through and taken a look at  changes to other parts of the tree (the `SConstruct` files are very different) and I haven't tried to build this version.

It seems that the two histories diverge at d14a369 from March 2012 (see also lsst/ndarray@d14a369).