### PR TITLE
Make dependencies optional in cmake build.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,10 +2,23 @@ cmake_minimum_required(VERSION 2.8.11)
 
 project(ndarray)
 
+# Build is split into two broad passes:
+# (1) Generation, which performs macro-expansion and header installation.
+# (2) Test, which builds & executes zero-dependency core and (optional) dependent tests.
+#
+# The generation phase does not rely on the presence of external libraries,
+# though the installed headers may be dependent on these libraries. This allows
+# generation & installation of ndarray as a vendorized dependency of external
+# projects without ndarry's optional dependencies.
+#
+# The test phase may rely on external libraries, which are enabled via the
+# options below. Library resolution is deferred to tests/CMakeLists.txt and
+# only executed if NDARRAY_TEST is enabled.
+option(NDARRAY_SWIG "Enable .i file installation and swig tests?" OFF)
 option(NDARRAY_TEST "Enable tests?" ON)
-option(NDARRAY_SWIG "Enable Swig?" ON)
-option(NDARRAY_BOOST_PYTHON "Enable Boost Python?" OFF)
-option(NDARRAY_PYBIND11 "Enable Pybind11?" OFF)
+option(NDARRAY_EIGEN "Enable Eigen tests?" ON)
+option(NDARRAY_FFTW "Enable FFTW tests?" ON)
+option(NDARRAY_PYBIND11 "Enable Pybind11 tests?" OFF)
 
 # enable C++11 support
 add_definitions(-std=c++11)
@@ -13,41 +26,6 @@ add_definitions(-std=c++11)
 # put our local cmake find scripts at the beginning of the cmake
 # module search path
 set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake ${CMAKE_MODULE_PATH})
-
-# find required packages
-find_package(PythonInterp REQUIRED)
-find_package(PythonLibs REQUIRED)
-find_package(NumPy REQUIRED)
-find_package(Boost COMPONENTS unit_test_framework REQUIRED)
-find_package(FFTW REQUIRED)
-
-# allow user to specify EIGEN_DIR as an environment variable
-# this is necessary to integrate with build systems that install Eigen
-# in non-standard locations
-set(EIGEN3_INCLUDE_DIR $ENV{EIGEN_DIR})
-if(NOT EIGEN3_INCLUDE_DIR)
-	find_package(Eigen3 REQUIRED)
-else()
-	set(EIGEN3_INCLUDE_DIR ${EIGEN3_INCLUDE_DIR}/include)
-endif(NOT EIGEN3_INCLUDE_DIR)
-
-if (NDARRAY_SWIG)
-	find_package(SWIG REQUIRED)
-endif (NDARRAY_SWIG)
-
-if (NDARRAY_PYBIND11)
-	find_package(Pybind11 REQUIRED)
-endif (NDARRAY_PYBIND11)
-
-include_directories(
-	${PROJECT_SOURCE_DIR}/include
-	${PYTHON_INCLUDE_DIRS}
-	${NUMPY_INCLUDE_DIRS}
-	${Boost_INCLUDE_DIRS}
-	${FFTW_INCLUDES}
-	${EIGEN3_INCLUDE_DIR}
-	${PYBIND11_INCLUDE_DIR}
-	)
 
 add_subdirectory(include)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ project(ndarray)
 # The test phase may rely on external libraries, which are enabled via the
 # options below. Library resolution is deferred to tests/CMakeLists.txt and
 # only executed if NDARRAY_TEST is enabled.
-option(NDARRAY_SWIG "Enable .i file installation and swig tests?" OFF)
+option(NDARRAY_SWIG "Enable .i file installation and swig tests?" ON)
 option(NDARRAY_TEST "Enable tests?" ON)
 option(NDARRAY_EIGEN "Enable Eigen tests?" ON)
 option(NDARRAY_FFTW "Enable FFTW tests?" ON)

--- a/README
+++ b/README
@@ -25,14 +25,21 @@ ndarray clone.
 
 A partial cmake build has also recently been added, and we expect it to
 eventually replace SCons as the recommended approach, but it does not yet
-support building against Boost.NumPy to provide bindings for Boost.Python.  To
-build with cmake, do:
+support building against Boost.NumPy to provide bindings for Boost.Python. 
+
+To build with cmake, do:
 
     mkdir build
     cd build
     cmake ..
     make
+    make test
 
+Inclusion and testing of optional dependencies is controlled by NDARRAY_* cmake
+options. Dependency resolution can be controlled by the PYBIND11_DIR,
+EIGEN_DIR, and FFTW_DIR environment variables. For example, to build with an
+alternate Eigen3 install location and disable FFTW testing replace `cmake ..`
+with `EIGEN_DIR=/opt/local cmake -DNDARRY_FFTW=OFF ..`.
 
 BUILDING FROM COMPRESSED SOURCE
 

--- a/cmake/FindFFTW.cmake
+++ b/cmake/FindFFTW.cmake
@@ -21,6 +21,11 @@ if( NOT FFTW_ROOT AND ENV{FFTWDIR} )
   set( FFTW_ROOT $ENV{FFTWDIR} )
 endif()
 
+#Add FFTW_DIR support to mirror other dependencies
+if( NOT FFTW_ROOT AND ENV{FFTW_DIR} )
+  set( FFTW_ROOT $ENV{FFTW_DIR} )
+endif()
+
 # Check if we can use PkgConfig
 find_package(PkgConfig)
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,21 +1,65 @@
+# Tests are split by feature & dependency and are enabled on a
+# per-dependency basis.
+#
+# A test is formatted as:
+# (1) An if-guard over an appropriate option.
+# (2) Resolution and inclusion of any required dependencies.
+# (3) Build of the test executable.
+# (4) Addition of the test executable via add_test.
+
+### Core tests, which rely only on boost-test and ndarray.
+find_package(Boost COMPONENTS unit_test_framework REQUIRED)
+
+include_directories(
+	${PROJECT_SOURCE_DIR}/include
+	${Boost_INCLUDE_DIRS}
+)
+
 add_executable(ndarray ndarray.cc)
 target_link_libraries(ndarray ${Boost_LIBRARIES})
+add_test(test_ndarray ndarray)
 
 add_executable(views views.cc)
 target_link_libraries(views ${Boost_LIBRARIES})
-
-add_executable(ndarray-eigen ndarray-eigen.cc)
-target_link_libraries(ndarray-eigen ${Boost_LIBRARIES})
-
-add_executable(ndarray-fft ndarray-fft.cc)
-target_link_libraries(ndarray-fft ${Boost_LIBRARIES} ${FFTW_LIBRARIES})
-
-add_test(test_ndarray ndarray)
 add_test(test_views views)
-add_test(test_ndarray-fft ndarray-fft)
-add_test(test_ndarray_eigen ndarray-eigen)
 
+
+### Eigen dependency tests
+if(NDARRAY_EIGEN)
+  find_package(Eigen3 REQUIRED)
+
+  include_directories( ${EIGEN3_INCLUDE_DIR} )
+
+  add_executable(ndarray-eigen ndarray-eigen.cc)
+  target_link_libraries(ndarray-eigen ${Boost_LIBRARIES})
+  add_test(test_ndarray_eigen ndarray-eigen)
+endif(NDARRAY_EIGEN)
+
+### FFTW dependency tests
+if(NDARRAY_FFTW)
+  find_package(FFTW REQUIRED)
+  include_directories( ${FFTW_INCLUDES} )
+
+  add_executable(ndarray-fft ndarray-fft.cc)
+  target_link_libraries(ndarray-fft ${Boost_LIBRARIES} ${FFTW_LIBRARIES})
+  add_test(test_ndarray-fft ndarray-fft)
+endif(NDARRAY_FFTW)
+
+### Python resolution
+if(NDARRAY_SWIG OR NDARRAY_PYBIND11)
+  find_package(PythonInterp REQUIRED)
+  find_package(PythonLibs REQUIRED)
+  find_package(NumPy REQUIRED)
+
+  include_directories(
+    ${PYTHON_INCLUDE_DIRS}
+    ${NUMPY_INCLUDE_DIRS}
+  )
+ENDIF()
+
+###SWIG dependency tests
 if(NDARRAY_SWIG)
+	find_package(SWIG REQUIRED)
 	include(${SWIG_USE_FILE})
 
 	set_property(SOURCE swig_test_mod.i PROPERTY CPLUSPLUS ON)
@@ -27,14 +71,18 @@ if(NDARRAY_SWIG)
 		swig_link_libraries(swig_test_mod "-shared")
 	endif()
 
-	find_package(PythonInterp REQUIRED)
 	configure_file(swig_test.py swig_test.py COPYONLY)
 	add_test(NAME swig_test
 		COMMAND ${PYTHON_EXECUTABLE}
 		${CMAKE_CURRENT_BINARY_DIR}/swig_test.py)
 endif(NDARRAY_SWIG)
 
+###Pybind11 dependency tests
 if(NDARRAY_PYBIND11)
+	find_package(Pybind11 REQUIRED)
+
+  include_directories(${PYBIND11_INCLUDE_DIR})
+
 	add_library(pybind11_test_mod.so MODULE pybind11_test_mod.cc)
 	set_target_properties(pybind11_test_mod.so PROPERTIES PREFIX "${PYTHON_MODULE_PREFIX}")
 	set_target_properties(pybind11_test_mod.so PROPERTIES SUFFIX "${PYTHON_MODULE_EXTENSION}")


### PR DESCRIPTION
Update cmake build system to make all external dependencies optional
during build. This allows dependency-free header generation and
installation if tests are not required.

Add options for all external dependencies. Move dependency resolution to
`tests/CMakeLists.txt` and add per-option guards.  Minor update to
CMakeLists supporting env-based dependency location resolution.

Update CMakeLists to describe build structure and README with cmake
build example.