### PR TITLE
Restore boost 1.55 compatibility in pybind11 support.

### DIFF
--- a/include/ndarray/pybind11.h
+++ b/include/ndarray/pybind11.h
@@ -59,7 +59,7 @@ template <typename T, int N, int C>
 class type_caster< ndarray::Array<T,N,C> > {
 public:
     bool load(handle src, bool) {
-        _src.reset(src.ptr(), true); // keep alive for stage 2
+        _src.reset(src.ptr()); // equivalent to add_ref=true, keep alive for stage 2
         if (!ndarray::PyConverter< ndarray::Array<T,N,C> >::fromPythonStage1(_src)) {
             PyErr_Clear();
             return false;
@@ -96,7 +96,7 @@ template <typename T, int N, int C, typename Kind, int Rows, int Cols>
 class type_caster< ndarray::EigenView<T,N,C,Kind,Rows,Cols> > {
 public:
     bool load(handle src, bool) {
-        _src.reset(src.ptr(), true); // keep alive for stage 2
+        _src.reset(src.ptr()); // equivalent to add_ref=true, keep alive for stage 2
         if (!ndarray::PyConverter< ndarray::EigenView<T,N,C,Kind,Rows,Cols> >::fromPythonStage1(_src)) {
             PyErr_Clear();
             return false;
@@ -133,7 +133,7 @@ template<typename T, int R, int C, int O, int MR, int MC>
 class type_caster< Eigen::Array<T,R,C,O,MR,MC> > {
 public:
     bool load(handle src, bool) {
-        _src.reset(src.ptr(), true); // keep alive for stage 2
+        _src.reset(src.ptr()); // equivalent to add_ref=true, keep alive for stage 2
         if (!ndarray::PyConverter< Eigen::Array<T,R,C,O,MR,MC> >::fromPythonStage1(_src)) {
             PyErr_Clear();
             return false;
@@ -170,7 +170,7 @@ template<typename T, int R, int C, int O, int MR, int MC>
 class type_caster< Eigen::Matrix<T,R,C,O,MR,MC> > {
 public:
     bool load(handle src, bool) {
-        _src.reset(src.ptr(), true); // keep alive for stage 2
+        _src.reset(src.ptr()); // equivalent to add_ref=true, keep alive for stage 2
         if (!ndarray::PyConverter< Eigen::Matrix<T,R,C,O,MR,MC> >::fromPythonStage1(_src)) {
             PyErr_Clear();
             return false;


### PR DESCRIPTION
`boost::intrustive_ptr::reset(T * r, bool add_ref)` was added in boost
1.56. Use of this overload, though helpfully explicit, breaks
compatibility with older boost versions. For example, 1.55 is the
default install in debian 8 and is widely used.

`reset(t, true)` is equivalent to `reset(t)`, which can be used to
preserve backward compatibility. For details see:

http://www.boost.org/doc/libs/1_55_0/libs/smart_ptr/intrusive_ptr.html#Synopsis
http://www.boost.org/doc/libs/1_56_0/libs/smart_ptr/intrusive_ptr.html#Synopsis