### PR TITLE
Re-try of PR # 76: switch to header version of Boost unit test.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ install:
   - conda config --env --add channels conda-forge
   - source activate test-environment
   - conda config --env --add channels conda-forge
-  - conda install python=$TRAVIS_PYTHON_VERSION boost fftw numpy pybind11=2.2.* swig cmake compilers eigen
+  - conda install python=$TRAVIS_PYTHON_VERSION boost fftw numpy pybind11=2.2.* swig cmake compilers eigen=3.2.*
   - export BOOST_DIR=$CONDA_PREFIX
   - export EIGEN_DIR=$CONDA_PREFIX
   - export FFTW_DIR=$CONDA_PREFIX

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ install:
   - conda config --env --add channels conda-forge
   - source activate test-environment
   - conda config --env --add channels conda-forge
-  - conda install python=$TRAVIS_PYTHON_VERSION boost fftw numpy pybind11 swig cmake compilers eigen
+  - conda install python=$TRAVIS_PYTHON_VERSION boost fftw numpy pybind11=2.2.* swig cmake compilers eigen
   - export BOOST_DIR=$CONDA_PREFIX
   - export EIGEN_DIR=$CONDA_PREFIX
   - export FFTW_DIR=$CONDA_PREFIX

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,11 @@ install:
   - conda update -q conda
   # Useful for debugging any issues with conda
   - conda info -a
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION boost fftw numpy pybind11 swig cmake gxx_linux-64
+  - conda create -q -n test-environment 
+  - conda config --env --add channels conda-forge
   - source activate test-environment
+  - conda config --env --add channels conda-forge
+  - conda install python=$TRAVIS_PYTHON_VERSION boost fftw numpy pybind11 swig cmake compilers
   - echo "eigen 3.2.*" > $CONDA_PREFIX/conda-meta/pinned
   - conda install eigen
   - export BOOST_DIR=$CONDA_PREFIX

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,6 @@ install:
   # Useful for debugging any issues with conda
   - conda info -a
   - conda create -q -n test-environment 
-  - conda config --env --add channels conda-forge
   - source activate test-environment
   - conda config --env --add channels conda-forge
   - conda install python=$TRAVIS_PYTHON_VERSION boost fftw numpy pybind11=2.2.* swig cmake compilers eigen=3.2.*
@@ -31,6 +30,8 @@ install:
   - export EIGEN_DIR=$CONDA_PREFIX
   - export FFTW_DIR=$CONDA_PREFIX
   - export CMAKE_PREFIX_PATH=$CONDA_PREFIX
+  # For conda-forge's old glibc
+  - export LDFLAGS="-lrt ${LDFLAGS}"
 
 script:
   - mkdir build

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,9 +26,7 @@ install:
   - conda config --env --add channels conda-forge
   - source activate test-environment
   - conda config --env --add channels conda-forge
-  - conda install python=$TRAVIS_PYTHON_VERSION boost fftw numpy pybind11 swig cmake compilers
-  - echo "eigen 3.2.*" > $CONDA_PREFIX/conda-meta/pinned
-  - conda install eigen
+  - conda install python=$TRAVIS_PYTHON_VERSION boost fftw numpy pybind11 swig cmake compilers eigen
   - export BOOST_DIR=$CONDA_PREFIX
   - export EIGEN_DIR=$CONDA_PREFIX
   - export FFTW_DIR=$CONDA_PREFIX

--- a/tests/ndarray-eigen.cc
+++ b/tests/ndarray-eigen.cc
@@ -12,9 +12,8 @@
 #include "ndarray/buildOptions.h"
 #include "Eigen/SVD"
 
-#define BOOST_TEST_DYN_LINK
 #define BOOST_TEST_MODULE ndarray-eigen
-#include "boost/test/unit_test.hpp"
+#include "boost/test/included/unit_test.hpp"
 
 template <typename T, typename U>
 void testElements2(T const & a, U const & b) {

--- a/tests/ndarray-fft.cc
+++ b/tests/ndarray-fft.cc
@@ -10,9 +10,8 @@
  */
 #include <ndarray/fft.h>
 
-#define BOOST_TEST_DYN_LINK
 #define BOOST_TEST_MODULE ndarray-fft
-#include "boost/test/unit_test.hpp"
+#include "boost/test/included/unit_test.hpp"
 
 #include <sstream>
 

--- a/tests/ndarray.cc
+++ b/tests/ndarray.cc
@@ -10,9 +10,8 @@
  */
 #include "ndarray.h"
 
-#define BOOST_TEST_DYN_LINK
 #define BOOST_TEST_MODULE ndarray
-#include "boost/test/unit_test.hpp"
+#include "boost/test/included/unit_test.hpp"
 
 BOOST_AUTO_TEST_CASE(sizes) {
     std::cerr << "sizeof(int): " << sizeof(int) << "\n";

--- a/tests/views.cc
+++ b/tests/views.cc
@@ -10,9 +10,8 @@
  */
 #include "ndarray.h"
 
-#define BOOST_TEST_DYN_LINK
 #define BOOST_TEST_MODULE views
-#include "boost/test/unit_test.hpp"
+#include "boost/test/included/unit_test.hpp"
 
 template <typename T, int N, int C>
 int templateC(ndarray::ArrayRef<T,N,C> const &) { return C; }


### PR DESCRIPTION
Previous PR (#76) caused a Travis failure after merge to master and was quickly reverted, which is quite strange considering that Travis passed on the branch.