### PR TITLE
test: replace deprecated pybind11 module declaration

### DIFF
--- a/tests/pybind11_test_mod.cc
+++ b/tests/pybind11_test_mod.cc
@@ -63,9 +63,7 @@ int acceptNoneArray(ndarray::Array<double, 1, 1> const * array = nullptr) {
     }
 }
 
-PYBIND11_PLUGIN(pybind11_test_mod) {
-    pybind11::module mod("pybind11_test_mod", "Tests for the ndarray library");
-
+PYBIND11_MODULE(pybind11_test_mod, mod) {
     mod.def("returnArray1", returnArray1);
     mod.def("returnConstArray1", returnConstArray1);
     mod.def("returnArray3", returnArray3);
@@ -74,6 +72,4 @@ PYBIND11_PLUGIN(pybind11_test_mod) {
     mod.def("acceptArray10", acceptArray10);
     mod.def("acceptArray3", acceptArray3);
     mod.def("acceptNoneArray", acceptNoneArray, "array"_a = nullptr);
-
-    return mod.ptr();
 }


### PR DESCRIPTION
When building with pybind11 2.8.0, we get a deprecation
warning:

.../ndarray/tests/pybind11_test_mod.cc:66:1: warning:
      'pybind11_init' is deprecated: PYBIND11_PLUGIN is deprecated, use
      PYBIND11_MODULE [-Wdeprecated-declarations]
PYBIND11_PLUGIN(pybind11_test_mod) {
^

Updated to use PYBIND11_MODULE, as suggested.