### PR TITLE
cmake: upgrade python finding

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -39,7 +39,7 @@ jobs:
         # Note the current convention is to use the -S and -B options here to specify source
         # and build directories, but this is only available with CMake 3.13 and higher.
         # The CMake binaries on the Github Actions machines are (as of this writing) 3.12
-        run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DNDARRAY_PYBIND11=ON -DCMAKE_PREFIX_PATH=$CONDA_PREFIX
+        run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DNDARRAY_PYBIND11=ON -DCMAKE_PREFIX_PATH=$CONDA_PREFIX -DPYTHON_VERSION=${{matrix.python-version}}
 
       - name: Build
         working-directory: ${{github.workspace}}/build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1 )
+cmake_minimum_required(VERSION 3.15)
 project(ndarray LANGUAGES CXX)
 set (CMAKE_CXX_STANDARD 11)
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -46,8 +46,7 @@ endif(NDARRAY_FFTW)
 
 ### Python resolution
 if(NDARRAY_PYBIND11)
-    find_package(PythonInterp COMPONENTS Interpreter NumPy REQUIRED)
-    find_package(PythonLibs REQUIRED)
+    find_package(Python ${PYTHON_VERSION} COMPONENTS Interpreter Development NumPy REQUIRED)
 ENDIF()
 
 ###Pybind11 dependency tests (also depend on Eigen)
@@ -59,7 +58,7 @@ if(NDARRAY_PYBIND11)
         target_link_libraries(pybind11_test_mod PRIVATE Eigen3::Eigen)
         configure_file(pybind11_test.py pybind11_test.py COPYONLY)
         add_test(NAME pybind11_test
-            COMMAND ${PYTHON_EXECUTABLE}
+            COMMAND ${Python_EXECUTABLE}
             ${CMAKE_CURRENT_BINARY_DIR}/pybind11_test.py)
     else(NDARRAY_EIGEN)
         message(STATUS "Skipping pybind11 tests as they depend on Eigen")


### PR DESCRIPTION
find_package(Python) is now recommended over separate
find_package(PythonInterp) and find_package(PythonLibs).