### PR TITLE
Fix inability to handle zero-size arrays with numpy>=1.23.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [2.7, 3.7, 3.8, 3.9]
+        python-version: ["2.7", "3.7", "3.8", "3.9", "3.10"]
     steps:
       - uses: actions/checkout@v2
       - uses: conda-incubator/setup-miniconda@v2

--- a/etc/conda-forge-testing.yaml
+++ b/etc/conda-forge-testing.yaml
@@ -7,5 +7,7 @@ dependencies:
  - fftw
  - numpy
  - pybind11
- - gxx_linux-64
+ - c-compiler
  - eigen
+ - cmake
+ - pkg-config

--- a/include/ndarray/pybind11.h
+++ b/include/ndarray/pybind11.h
@@ -120,6 +120,13 @@ Pybind11Helper {
         pybind11_np_size_t const * strides = wrapper.strides();
         pybind11_np_size_t const itemsize = wrapper.itemsize();
         if (C > 0) {
+            // If the shape is zero in any dimension, we don't
+            // worry about the strides.
+            for (int i = 0; i < C; ++i) {
+                if (shape[N-i-1] == 0) {
+                    return true;
+                }
+            }
             pybind11_np_size_t requiredStride = itemsize;
             for (int i = 0; i < C; ++i) {
                 if (strides[N-i-1] != requiredStride) {
@@ -128,6 +135,13 @@ Pybind11Helper {
                 requiredStride *= shape[N-i-1];
             }
         } else if (C < 0) {
+            // If the shape is zero in any dimension, we don't
+            // worry about the strides.
+            for (int i = 0; i < -C; ++i) {
+                if (shape[i] == 0) {
+                    return true;
+                }
+            }
             pybind11_np_size_t requiredStride = itemsize;
             for (int i = 0; i < -C; ++i) {
                 if (strides[i] != requiredStride) {

--- a/tests/pybind11_test.py
+++ b/tests/pybind11_test.py
@@ -40,10 +40,10 @@ class TestNumpyPybind11(unittest.TestCase):
         array = numpy.zeros(1, dtype=float)
         # just test that these don't throw
         pybind11_test_mod.acceptArray10(array)
-        pybind11_test_mod.acceptArray10(array)
+        pybind11_test_mod.acceptArray1(array)
         array = numpy.zeros(0, dtype=float)
         pybind11_test_mod.acceptArray10(array)
-        pybind11_test_mod.acceptArray10(array)
+        pybind11_test_mod.acceptArray1(array)
         # test that we gracefully fail when the strides are no multiples of the itemsize
         dtype = numpy.dtype([("f1", numpy.float64), ("f2", numpy.int16)])
         table = numpy.zeros(3, dtype=dtype)


### PR DESCRIPTION
Numpy updated the code to give zero stride for arrays that have zero in any dimension.  This should still match the ndarray usage in pybind11.