### PR TITLE
Fix acceptance tests and restore installation of .h files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,3 +32,6 @@ if(NDARRAY_TEST)
     add_subdirectory(tests)
 endif(NDARRAY_TEST)
 
+# installation
+install(DIRECTORY include/ DESTINATION include/
+        FILES_MATCHING PATTERN "*.h")

--- a/tests/pybind11_test.py
+++ b/tests/pybind11_test.py
@@ -40,10 +40,10 @@ class TestNumpyPybind11(unittest.TestCase):
         array = numpy.zeros(1, dtype=float)
         # just test that these don't throw
         pybind11_test_mod.acceptArray10(array)
-        pybind11_test_mod.acceptArray1(array)
+        pybind11_test_mod.acceptArray11(array)
         array = numpy.zeros(0, dtype=float)
         pybind11_test_mod.acceptArray10(array)
-        pybind11_test_mod.acceptArray1(array)
+        pybind11_test_mod.acceptArray11(array)
         # test that we gracefully fail when the strides are no multiples of the itemsize
         dtype = numpy.dtype([("f1", numpy.float64), ("f2", numpy.int16)])
         table = numpy.zeros(3, dtype=dtype)

--- a/tests/pybind11_test.py
+++ b/tests/pybind11_test.py
@@ -41,15 +41,16 @@ class TestNumpyPybind11(unittest.TestCase):
         # the zero shape array tests are simply checking that pybind11 can handle
         # arbitrary strides (non-zero for length 1 array, zero for length 0 array
         # for numpy >= 1.23).
-        pybind11_test_mod.acceptZeroShapeArray10(array)
-        pybind11_test_mod.acceptZeroShapeArray11(array)
+        pybind11_test_mod.acceptAnyArray10(array)
+        pybind11_test_mod.acceptAnyArray11(array)
         array = numpy.zeros(0, dtype=float)
-        pybind11_test_mod.acceptZeroShapeArray10(array)
-        pybind11_test_mod.acceptZeroShapeArray11(array)
+        pybind11_test_mod.acceptAnyArray10(array)
+        pybind11_test_mod.acceptAnyArray11(array)
         # test that we gracefully fail when the strides are no multiples of the itemsize
         dtype = numpy.dtype([("f1", numpy.float64), ("f2", numpy.int16)])
         table = numpy.zeros(3, dtype=dtype)
-        self.assertRaises(TypeError, pybind11_test_mod.acceptArray10, table['f1'])
+        self.assertRaises(TypeError, pybind11_test_mod.acceptAnyArray10, table['f1'])
+        self.assertRaises(TypeError, pybind11_test_mod.acceptAnyArray11, table['f1'])
 
     def testNone(self):
         array = numpy.zeros(10, dtype=float)
@@ -62,7 +63,8 @@ class TestNumpyPybind11(unittest.TestCase):
         d2 = numpy.dtype(">f8")
         nonnative = d2 if d1 == numpy.dtype(float) else d1
         a = numpy.zeros(5, dtype=nonnative)
-        self.assertRaises(TypeError, pybind11_test_mod.acceptArray10, a)
+        self.assertRaises(TypeError, pybind11_test_mod.acceptAnyArray10, a)
+        self.assertRaises(TypeError, pybind11_test_mod.acceptAnyArray11, a)
 
 
 if __name__ == "__main__":

--- a/tests/pybind11_test.py
+++ b/tests/pybind11_test.py
@@ -38,12 +38,14 @@ class TestNumpyPybind11(unittest.TestCase):
         # in NumPy 1.8+ 1- and 0-sized arrays can have arbitrary strides; we should
         # be able to handle those
         array = numpy.zeros(1, dtype=float)
-        # just test that these don't throw
-        pybind11_test_mod.acceptArray10(array)
-        pybind11_test_mod.acceptArray11(array)
+        # the zero shape array tests are simply checking that pybind11 can handle
+        # arbitrary strides (non-zero for length 1 array, zero for length 0 array
+        # for numpy >= 1.23).
+        pybind11_test_mod.acceptZeroShapeArray10(array)
+        pybind11_test_mod.acceptZeroShapeArray11(array)
         array = numpy.zeros(0, dtype=float)
-        pybind11_test_mod.acceptArray10(array)
-        pybind11_test_mod.acceptArray11(array)
+        pybind11_test_mod.acceptZeroShapeArray10(array)
+        pybind11_test_mod.acceptZeroShapeArray11(array)
         # test that we gracefully fail when the strides are no multiples of the itemsize
         dtype = numpy.dtype([("f1", numpy.float64), ("f2", numpy.int16)])
         table = numpy.zeros(3, dtype=dtype)

--- a/tests/pybind11_test_mod.cc
+++ b/tests/pybind11_test_mod.cc
@@ -41,6 +41,8 @@ bool acceptArray1(ndarray::Array<double,1,1> const & a1) {
 
 void acceptArray10(ndarray::Array<double,1,0> const & a1) {}
 
+void acceptArray11(ndarray::Array<double,1,1> const & a1) {}
+
 bool acceptArray3(ndarray::Array<double,3> const & a1) {
     ndarray::Array<double,3> a2 = returnArray3();
 #ifndef GCC_45
@@ -70,6 +72,7 @@ PYBIND11_MODULE(pybind11_test_mod, mod) {
     mod.def("returnConstArray3", returnConstArray3);
     mod.def("acceptArray1", acceptArray1);
     mod.def("acceptArray10", acceptArray10);
+    mod.def("acceptArray11", acceptArray11);
     mod.def("acceptArray3", acceptArray3);
     mod.def("acceptNoneArray", acceptNoneArray, "array"_a = nullptr);
 }

--- a/tests/pybind11_test_mod.cc
+++ b/tests/pybind11_test_mod.cc
@@ -39,9 +39,9 @@ bool acceptArray1(ndarray::Array<double,1,1> const & a1) {
 #endif
 }
 
-void acceptZeroShapeArray10(ndarray::Array<double,1,0> const & a1) {}
+void acceptAnyArray10(ndarray::Array<double,1,0> const & a1) {}
 
-void acceptZeroShapeArray11(ndarray::Array<double,1,1> const & a1) {}
+void acceptAnyArray11(ndarray::Array<double,1,1> const & a1) {}
 
 bool acceptArray3(ndarray::Array<double,3> const & a1) {
     ndarray::Array<double,3> a2 = returnArray3();
@@ -71,8 +71,8 @@ PYBIND11_MODULE(pybind11_test_mod, mod) {
     mod.def("returnArray3", returnArray3);
     mod.def("returnConstArray3", returnConstArray3);
     mod.def("acceptArray1", acceptArray1);
-    mod.def("acceptZeroShapeArray10", acceptZeroShapeArray10);
-    mod.def("acceptZeroShapeArray11", acceptZeroShapeArray11);
+    mod.def("acceptAnyArray10", acceptAnyArray10);
+    mod.def("acceptAnyArray11", acceptAnyArray11);
     mod.def("acceptArray3", acceptArray3);
     mod.def("acceptNoneArray", acceptNoneArray, "array"_a = nullptr);
 }

--- a/tests/pybind11_test_mod.cc
+++ b/tests/pybind11_test_mod.cc
@@ -39,9 +39,9 @@ bool acceptArray1(ndarray::Array<double,1,1> const & a1) {
 #endif
 }
 
-void acceptArray10(ndarray::Array<double,1,0> const & a1) {}
+void acceptZeroShapeArray10(ndarray::Array<double,1,0> const & a1) {}
 
-void acceptArray11(ndarray::Array<double,1,1> const & a1) {}
+void acceptZeroShapeArray11(ndarray::Array<double,1,1> const & a1) {}
 
 bool acceptArray3(ndarray::Array<double,3> const & a1) {
     ndarray::Array<double,3> a2 = returnArray3();
@@ -71,8 +71,8 @@ PYBIND11_MODULE(pybind11_test_mod, mod) {
     mod.def("returnArray3", returnArray3);
     mod.def("returnConstArray3", returnConstArray3);
     mod.def("acceptArray1", acceptArray1);
-    mod.def("acceptArray10", acceptArray10);
-    mod.def("acceptArray11", acceptArray11);
+    mod.def("acceptZeroShapeArray10", acceptZeroShapeArray10);
+    mod.def("acceptZeroShapeArray11", acceptZeroShapeArray11);
     mod.def("acceptArray3", acceptArray3);
     mod.def("acceptNoneArray", acceptNoneArray, "array"_a = nullptr);
 }


### PR DESCRIPTION
The previous PR #98 actually shouldn't have passed tests because it was calling `acceptArray1` which was doing a comparison vs a known vector, rather than just testing acceptance.  This PR fixes the test (which mysteriously was passing in some instances even though it shouldn't).

This also restores the installation of the .h files which is (at least) needed by conda-forge and had been removed in https://github.com/ndarray/ndarray/commit/d151f9fadf75775d58bbbbb18a1450eec5c0cf35 