### PR TITLE
fix build w/ gcc-13

### DIFF
--- a/include/ndarray/formatting.h
+++ b/include/ndarray/formatting.h
@@ -19,6 +19,7 @@
 
 #include "ndarray/ExpressionBase.h"
 
+#include <cstdint>
 #include <iostream>
 
 namespace ndarray {


### PR DESCRIPTION
tried to build ndarray using the just released gcc-13.1, failed with compile time error "std::int8_t has not been declared"

after applying this PR, build of ndarray using gcc-13.1 succeeds 